### PR TITLE
Add support for using pattern to define export ABC filename

### DIFF
--- a/src/com/digero/common/util/Util.java
+++ b/src/com/digero/common/util/Util.java
@@ -356,8 +356,13 @@ public final class Util
 	{
 		return formatDuration(micros, 0);
 	}
-
+	
 	public static String formatDuration(long micros, long maxMicros)
+	{
+		return formatDuration(micros, maxMicros, ':');
+	}
+
+	public static String formatDuration(long micros, long maxMicros, char separator)
 	{
 		if (maxMicros < micros)
 			maxMicros = micros;
@@ -378,7 +383,7 @@ public final class Util
 
 		if (hrMax > 0)
 		{
-			s.append(hr).append(':');
+			s.append(hr).append(separator);
 			if (min < 10)
 			{
 				s.append('0');
@@ -388,7 +393,7 @@ public final class Util
 		{
 			s.append('0');
 		}
-		s.append(min).append(':');
+		s.append(min).append(separator);
 		if (sec < 10)
 		{
 			s.append('0');

--- a/src/com/digero/maestro/abc/AbcMetadataSource.java
+++ b/src/com/digero/maestro/abc/AbcMetadataSource.java
@@ -22,5 +22,7 @@ public interface AbcMetadataSource
 	
 	String getAllParts();
 	
+	int getPartCount();
+	
 	String getBadgerTitle();
 }

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -79,6 +79,7 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 	private SequenceInfo sequenceInfo;
 	private final PartAutoNumberer partAutoNumberer;
 	private final PartNameTemplate partNameTemplate;
+	private final ExportFilenameTemplate exportFilenameTemplate;
 	private QuantizedTimingInfo timingInfo;
 	private AbcExporter abcExporter;
 	private File sourceFile; // The MIDI or ABC file that this song was loaded from
@@ -91,7 +92,8 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 	boolean mixDirty = true;
 
 	public AbcSong(File file, PartAutoNumberer partAutoNumberer, PartNameTemplate partNameTemplate,
-			FileResolver fileResolver) throws IOException, InvalidMidiDataException, ParseException, SAXException
+			ExportFilenameTemplate exportFilenameTemplate, FileResolver fileResolver)
+			throws IOException, InvalidMidiDataException, ParseException, SAXException
 	{
 		sourceFile = file;
 
@@ -100,6 +102,9 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 
 		this.partNameTemplate = partNameTemplate;
 		this.partNameTemplate.setMetadataSource(this);
+		
+		this.exportFilenameTemplate = exportFilenameTemplate;
+		this.exportFilenameTemplate.setMetadataSource(this);
 
 		String fileName = file.getName().toLowerCase();
 		fromXmlFile = fileName.endsWith(MSX_FILE_EXTENSION);
@@ -544,6 +549,11 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 		if (count == 0) return null;
 		str += count+", ";
 		return str+str2;
+	}
+	
+	@Override public int getPartCount()
+	{
+		return getParts().size();
 	}
 
 	@Override public String getTranscriber()

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -29,7 +29,7 @@ public class ExportFilenameTemplate
 		private Settings(Preferences prefs)
 		{
 			exportFilenamePatternEnabled = prefs.getBoolean("exportFilenamePatternEnabled", false);
-			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount_$SongTitle");
+			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount - $SongTitle");
 			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
 		}
 
@@ -132,7 +132,7 @@ public class ExportFilenameTemplate
 		{
 			@Override public String getValue()
 			{
-				return Util.formatDuration(getMetadataSource().getSongLengthMicros());
+				return Util.formatDuration(getMetadataSource().getSongLengthMicros(), 0, '-');
 			}
 		});
 		variables.put("$SongComposer", new Variable("The song composer's name, as entered in the \"C:\" field")

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -1,0 +1,232 @@
+package com.digero.maestro.abc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.ListIterator;
+import java.util.HashMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.prefs.Preferences;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.digero.common.util.Pair;
+import com.digero.common.util.Util;
+import com.digero.maestro.view.SettingsDialog.MockMetadataSource;
+
+public class ExportFilenameTemplate
+{
+	public static final String spaceReplaceChars[] = {" ", "_", "-"};
+	public static final String spaceReplaceLabels[] = {"Don't Replace", "_ (Underscore)", "- (Dash)"};
+	
+	public static class Settings
+	{
+		private boolean exportFilenamePatternEnabled;
+		private String exportFilenamePattern;
+		private String whitespaceReplaceText;
+
+		private Settings(Preferences prefs)
+		{
+			exportFilenamePatternEnabled = prefs.getBoolean("exportFilenamePatternEnabled", false);
+			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount_$SongTitle");
+			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
+		}
+
+		public Settings(Settings source)
+		{
+			copyFrom(source);
+		}
+
+		private void save(Preferences prefs)
+		{
+			prefs.putBoolean("exportFilenamePatternEnabled", exportFilenamePatternEnabled);
+			prefs.put("exportFilenamePattern", exportFilenamePattern);
+			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
+		}
+
+		private void copyFrom(Settings source)
+		{
+			this.exportFilenamePatternEnabled = source.exportFilenamePatternEnabled;
+			this.exportFilenamePattern = source.exportFilenamePattern;
+			this.whitespaceReplaceText = source.whitespaceReplaceText;
+		}
+		
+		public boolean isExportFilenamePatternEnabled()
+		{
+			return exportFilenamePatternEnabled;
+		}
+		
+		public void setExportFilenamePatternEnabled(boolean exportFilenamePatternEnabled)
+		{
+			this.exportFilenamePatternEnabled = exportFilenamePatternEnabled;
+		}
+
+		public String getExportFilenamePattern()
+		{
+			return exportFilenamePattern;
+		}
+
+		public void setExportFilenamePattern(String exportFilenamePattern)
+		{
+			this.exportFilenamePattern = exportFilenamePattern;
+		}
+
+		public String getWhitespaceReplaceText()
+		{
+			return whitespaceReplaceText;
+		}
+
+		public void setWhitespaceReplaceText(String whitespaceReplaceText)
+		{
+			this.whitespaceReplaceText = whitespaceReplaceText;
+		}
+	}
+
+	public static abstract class Variable
+	{
+		private String description;
+
+		private Variable(String description)
+		{
+			this.description = description;
+		}
+
+		public abstract String getValue();
+
+		public String getDescription()
+		{
+			return description;
+		}
+
+		@Override public String toString()
+		{
+			return getValue();
+		}
+	}
+
+	private Settings settings;
+	private Preferences prefsNode;
+
+	private AbcMetadataSource metadata = null;
+
+	private SortedMap<String, Variable> variables;
+
+	public ExportFilenameTemplate(Preferences prefsNode)
+	{
+		this.prefsNode = prefsNode;
+		this.settings = new Settings(prefsNode);
+
+		Comparator<String> caseInsensitiveStringComparator = String::compareToIgnoreCase;
+
+		variables = new TreeMap<>(caseInsensitiveStringComparator);
+
+		variables.put("$SongTitle", new Variable("The title of the song, as entered in the \"T:\" field")
+		{
+			@Override public String getValue()
+			{
+				return getMetadataSource().getSongTitle().trim();
+			}
+		});
+		variables.put("$SongLength", new Variable("The playing time of the song in mm_ss format")
+		{
+			@Override public String getValue()
+			{
+				return Util.formatDuration(getMetadataSource().getSongLengthMicros());
+			}
+		});
+		variables.put("$SongComposer", new Variable("The song composer's name, as entered in the \"C:\" field")
+		{
+			@Override public String getValue()
+			{
+				return getMetadataSource().getComposer().trim();
+			}
+		});
+		variables.put("$SongTranscriber", new Variable("Your name, as entered in the \"Z:\" field")
+		{
+			@Override public String getValue()
+			{
+				return getMetadataSource().getTranscriber().trim();
+			}
+		});
+		variables.put("$PartCount", new Variable("Number of parts in the ABC file")
+		{
+			@Override public String getValue()
+			{
+				return String.valueOf(getMetadataSource().getPartCount());
+			}
+		});
+	}
+
+	public Settings getSettingsCopy()
+	{
+		return new Settings(settings);
+	}
+
+	public void setSettings(Settings settings)
+	{
+		this.settings.copyFrom(settings);
+		this.settings.save(prefsNode);
+	}
+
+	public AbcMetadataSource getMetadataSource()
+	{
+		if (metadata == null)
+			metadata = new MockMetadataSource(null);
+
+		return metadata;
+	}
+
+	public void setMetadataSource(AbcMetadataSource metadata)
+	{
+		this.metadata = metadata;
+	}
+
+	public SortedMap<String, Variable> getVariables()
+	{
+		return Collections.unmodifiableSortedMap(variables);
+	}
+	
+	public boolean isEnabled()
+	{
+		return settings.isExportFilenamePatternEnabled();
+	}
+
+	public String formatName()
+	{
+		return formatName(settings);
+	}
+
+	public String formatName(ExportFilenameTemplate.Settings settings)
+	{
+		String name = settings.getExportFilenamePattern();
+
+		// Find all variables starting with $
+		Pattern regex = Pattern.compile("\\$[A-Za-z]+");
+		Matcher matcher = regex.matcher(name);
+
+		ArrayList<Pair<Integer, Integer>> matches = new ArrayList<>();
+		while (matcher.find())
+		{
+			matches.add(new Pair<>(matcher.start(), matcher.end()));
+		}
+
+		ListIterator<Pair<Integer, Integer>> reverseIter = matches.listIterator(matches.size());
+		while (reverseIter.hasPrevious())
+		{
+			Pair<Integer, Integer> match = reverseIter.previous();
+			Variable var = variables.get(name.substring(match.first, match.second));
+			if (var != null)
+			{
+				String value = var.getValue();
+				value = value.replaceAll("\\s+", settings.getWhitespaceReplaceText());
+				name = name.substring(0, match.first) + value + name.substring(match.second);
+			}
+		}
+		
+		// This will be removed and re-added by exportAbcAs(), but adding it here so it previews in the settings menu
+		name = name + ".abc";
+		
+		return name;
+	}
+}

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -110,6 +110,7 @@ import com.digero.maestro.abc.AbcPartEvent.AbcPartProperty;
 import com.digero.maestro.abc.AbcPartMetadataSource;
 import com.digero.maestro.abc.AbcSong;
 import com.digero.maestro.abc.AbcSongEvent;
+import com.digero.maestro.abc.ExportFilenameTemplate;
 import com.digero.maestro.abc.PartAutoNumberer;
 import com.digero.maestro.abc.PartNameTemplate;
 import com.digero.maestro.midi.SequenceInfo;
@@ -140,6 +141,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private VolumeTransceiver abcVolumeTransceiver;
 	private PartAutoNumberer partAutoNumberer;
 	private PartNameTemplate partNameTemplate;
+	private ExportFilenameTemplate exportFilenameTemplate;
 	private SaveAndExportSettings saveSettings;
 	private boolean usingNativeVolume;
 
@@ -253,6 +255,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 		partAutoNumberer = new PartAutoNumberer(prefs.node("partAutoNumberer"));
 		partNameTemplate = new PartNameTemplate(prefs.node("partNameTemplate"));
+		exportFilenameTemplate = new ExportFilenameTemplate(prefs.node("exportFilenameTemplate"));
 		saveSettings = new SaveAndExportSettings(prefs.node("saveAndExportSettings"));
 
 		usingNativeVolume = MaestroMain.isNativeVolumeSupported();
@@ -1090,7 +1093,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private void doSettingsDialog(int tab)
 	{
 		SettingsDialog dialog = new SettingsDialog(ProjectFrame.this, partAutoNumberer.getSettingsCopy(),
-				partNameTemplate, saveSettings.getCopy());
+				partNameTemplate, exportFilenameTemplate, saveSettings.getCopy());
 		dialog.setActiveTab(tab);
 		dialog.setVisible(true);
 		if (dialog.isSuccess())
@@ -1101,6 +1104,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				partAutoNumberer.renumberAllParts();
 			}
 			partNameTemplate.setSettings(dialog.getNameTemplateSettings());
+			exportFilenameTemplate.setSettings(dialog.getExportFilenameTemplateSettings());
 			partPanel.settingsChanged();
 
 			saveSettings.copyFrom(dialog.getSaveAndExportSettings());
@@ -1878,7 +1882,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 		try
 		{
-			abcSong = new AbcSong(file, partAutoNumberer, partNameTemplate, openFileResolver);
+			abcSong = new AbcSong(file, partAutoNumberer, partNameTemplate, exportFilenameTemplate, openFileResolver);
 			abcSong.setAllOut(saveSettings.showBadger && saveSettings.allBadger);
 			abcSong.setBadger(saveSettings.showBadger);
 			abcSong.addSongListener(abcSongListener);
@@ -2245,10 +2249,19 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			String folder = prefs.get("exportDialogFolder", defaultFolder);
 			if (!new File(folder).exists())
 				folder = defaultFolder;
-
-			exportFile = abcSong.getSourceFile();
-			if (exportFile == null)
-				exportFile = new File(folder, abcSong.getSequenceInfo().getFileName());
+			
+			if (exportFilenameTemplate.isEnabled())
+			{
+				exportFile = new File(folder, exportFilenameTemplate.formatName());
+			}
+			else
+			{
+				exportFile = abcSong.getSourceFile();
+				if (exportFile == null)
+				{
+					exportFile = new File(folder, abcSong.getSequenceInfo().getFileName());
+				}
+			}
 
 			String fileName = exportFile.getName();
 			int dot = fileName.lastIndexOf('.');


### PR DESCRIPTION
- Added a new section to the Save & Export menu, "Pattern for ABC export filename"
- Allows for referring to variables which aren't tied to a part (also added part count)
- Added an option to replace spaces in variables with either "_" or "-" (e.g. if song name is A Song, you can export as A_Song or A-Song)
- If the pattern is enabled, when there isn't an existing export file reference, the pattern will pre-populate the filename in the "Export As" menu