### PR TITLE
Part count and empty part export fixes

### DIFF
--- a/src/com/digero/maestro/abc/AbcExporter.java
+++ b/src/com/digero/maestro/abc/AbcExporter.java
@@ -817,7 +817,10 @@ public class AbcExporter
 
 		for (AbcPart part : parts)
 		{
-			exportPartToAbc(part, exportStartTick, exportEndTick, out, delayEnabled);
+			if (part.getEnabledTrackCount() > 0)
+			{
+				exportPartToAbc(part, exportStartTick, exportEndTick, out, delayEnabled);
+			}
 		}
 	}
 

--- a/src/com/digero/maestro/abc/AbcMetadataSource.java
+++ b/src/com/digero/maestro/abc/AbcMetadataSource.java
@@ -22,7 +22,7 @@ public interface AbcMetadataSource
 	
 	String getAllParts();
 	
-	int getPartCount();
+	int getActivePartCount();
 	
 	String getBadgerTitle();
 }

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -560,9 +560,19 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 		return str+str2;
 	}
 	
-	@Override public int getPartCount()
+	@Override public int getActivePartCount()
 	{
-		return getParts().size();
+		// TODO: Cache this to not have to recalculate
+		ListModelWrapper<AbcPart> prts = getParts();
+		int counter = 0;
+		for (AbcPart part : prts)
+		{
+			if (part.getEnabledTrackCount() > 0)
+			{
+				counter++;
+			}
+		}
+		return counter;
 	}
 
 	@Override public String getTranscriber()

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -170,7 +170,7 @@ public class ExportFilenameTemplate
 		{
 			@Override public String getValue()
 			{
-				return String.format("%02d", getMetadataSource().getPartCount());
+				return String.format("%02d", getMetadataSource().getActivePartCount());
 			}
 		});
 	}

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1533,28 +1533,17 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			double[] LAYOUT_COLS_DYN = new double[] { partsList.getFixedCellWidth() + 32, FILL };
 			tableLayout.setColumn(LAYOUT_COLS_DYN);// This call is attempt of fix for no delete button on MacOS part 2
 			
+			String partListTitle = "Song Parts";
+			if (abcSong != null)
+			{
+				partListTitle = partListTitle + " (Count: " + abcSong.getActivePartCount() + ")";
+			}
+			
+			partsListPanel.setBorder(BorderFactory.createTitledBorder(partListTitle));
+			
 			updateButtonsPending = false;
 		}
 	};
-	
-	private boolean updatePartCountPending = false;
-	
-	public void updatePartCountIndicator() {
-		if (!updatePartCountPending)
-		{
-			updatePartCountPending = true;
-			SwingUtilities.invokeLater(() -> {
-				String partListTitle = "Song Parts";
-				if (abcSong != null)
-				{
-					partListTitle = partListTitle + " (Count: " + abcSong.getPartCount() + ")";
-				}
-				
-				partsListPanel.setBorder(BorderFactory.createTitledBorder(partListTitle));
-				updatePartCountPending = false;
-			});
-		}
-	}
 	
 	public void updateDelayButton () {
 		if (partsList.getSelectedIndex() != -1 && partPanel != null && partPanel.getAbcPart() != null && partPanel.getAbcPart().delay != 0) {
@@ -1717,7 +1706,6 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				partsList.ensureIndexIsVisible(idx);
 				partsList.repaint();
 				updateButtons(false);
-				updatePartCountIndicator();
 				maxNoteCountTotal = 0;
 				maxNoteCount = 0;
 				break;
@@ -1756,7 +1744,6 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 				partsList.repaint();
 				updateButtons(false);
-				updatePartCountIndicator();
 				maxNoteCountTotal = 0;
 				maxNoteCount = 0;
 				break;
@@ -1918,7 +1905,6 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		setAbcSongModified(false);
 		updateButtons(false);
 		updateTitle();
-		updatePartCountIndicator();
 		partPanel.setNote("");
 		partPanel.noteVisible(false);
 

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -905,7 +905,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 			return "N: TS  1,   4";
 		}
 		
-		@Override public int getPartCount()
+		@Override public int getActivePartCount()
 		{
 			return 5;
 		}


### PR DESCRIPTION
- Use active part count rather than total part count in calculating parts for display and filename export
- Trim non-active parts from ABC export