### PR TITLE
Make part list resizable, misc tweaks to filename export options

### DIFF
--- a/src/com/digero/maestro/abc/AbcMetadataSource.java
+++ b/src/com/digero/maestro/abc/AbcMetadataSource.java
@@ -25,4 +25,6 @@ public interface AbcMetadataSource
 	int getActivePartCount();
 	
 	String getBadgerTitle();
+	
+	String getSourceFilename();
 }

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -750,6 +750,16 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 	{
 		return sourceFile;
 	}
+	
+	public String getSourceFilename()
+	{
+		String ret = "ERROR";
+		if (sourceFile != null)
+		{
+			ret = sourceFile.getName();
+		}
+		return ret;
+	}
 
 	public File getSaveFile()
 	{

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -252,6 +252,7 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 			while (sequenceInfo == null)
 			{
 				String name = sourceFile.getName().toLowerCase();
+				System.out.println("name of file in msx: " + name);
 				boolean isAbc = name.endsWith(".abc") || name.endsWith(".txt");
 
 				try

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -252,7 +252,6 @@ public class AbcSong implements IDiscardable, AbcMetadataSource
 			while (sequenceInfo == null)
 			{
 				String name = sourceFile.getName().toLowerCase();
-				System.out.println("name of file in msx: " + name);
 				boolean isAbc = name.endsWith(".abc") || name.endsWith(".txt");
 
 				try

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -187,6 +187,13 @@ public class ExportFilenameTemplate
 				return String.format(settings.partCountZeroPadded? "%02d" : "%d", getMetadataSource().getActivePartCount());
 			}
 		});
+		variables.put("$SourceFile", new Variable("Source file name (midi or ABC)")
+		{
+			@Override public String getValue()
+			{
+				return getMetadataSource().getSourceFilename();
+			}
+		});
 	}
 
 	public Settings getSettingsCopy()

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -191,7 +191,7 @@ public class ExportFilenameTemplate
 		{
 			@Override public String getValue()
 			{
-				return getMetadataSource().getSourceFilename();
+				return getMetadataSource().getSourceFilename().replaceAll("\\.", " ");
 			}
 		});
 	}

--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -19,14 +19,15 @@ import com.digero.maestro.view.SettingsDialog.MockMetadataSource;
 
 public class ExportFilenameTemplate
 {
-	public static final String[] spaceReplaceChars = {" ", "_", "-"};
-	public static final String[] spaceReplaceLabels = {"Don't Replace", "_ (Underscore)", "- (Dash)"};
+	public static final String[] spaceReplaceChars = {" ", "", "_", "-"};
+	public static final String[] spaceReplaceLabels = {"Don't Replace", "Remove Spaces", "_ (Underscore)", "- (Dash)"};
 	
 	public static class Settings
 	{
 		private boolean exportFilenamePatternEnabled;
 		private String exportFilenamePattern;
 		private String whitespaceReplaceText;
+		private boolean partCountZeroPadded;
 		
 		private final Preferences prefs;
 
@@ -36,6 +37,7 @@ public class ExportFilenameTemplate
 			exportFilenamePatternEnabled = prefs.getBoolean("exportFilenamePatternEnabled", false);
 			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount - $SongTitle");
 			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
+			partCountZeroPadded = prefs.getBoolean("partCountZeroPadded", true);
 		}
 
 		public Settings(Settings source)
@@ -49,6 +51,7 @@ public class ExportFilenameTemplate
 			prefs.putBoolean("exportFilenamePatternEnabled", exportFilenamePatternEnabled);
 			prefs.put("exportFilenamePattern", exportFilenamePattern);
 			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
+			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
 		}
 
 		private void copyFrom(Settings source)
@@ -56,6 +59,7 @@ public class ExportFilenameTemplate
 			this.exportFilenamePatternEnabled = source.exportFilenamePatternEnabled;
 			this.exportFilenamePattern = source.exportFilenamePattern;
 			this.whitespaceReplaceText = source.whitespaceReplaceText;
+			this.partCountZeroPadded = source.partCountZeroPadded;
 		}
 		
 		public boolean isExportFilenamePatternEnabled()
@@ -86,6 +90,16 @@ public class ExportFilenameTemplate
 		public void setWhitespaceReplaceText(String whitespaceReplaceText)
 		{
 			this.whitespaceReplaceText = whitespaceReplaceText;
+		}
+		
+		public boolean isPartCountZeroPadded()
+		{
+			return partCountZeroPadded;
+		}
+		
+		public void setPartCountZeroPadded(boolean zeroPadded)
+		{
+			partCountZeroPadded = zeroPadded;
 		}
 		
 		public void restoreDefaults()
@@ -170,7 +184,7 @@ public class ExportFilenameTemplate
 		{
 			@Override public String getValue()
 			{
-				return String.format("%02d", getMetadataSource().getActivePartCount());
+				return String.format(settings.partCountZeroPadded? "%02d" : "%d", getMetadataSource().getActivePartCount());
 			}
 		});
 	}
@@ -217,6 +231,10 @@ public class ExportFilenameTemplate
 	public String formatName(ExportFilenameTemplate.Settings settings)
 	{
 		String name = settings.getExportFilenamePattern();
+		
+		// hacky but it works - save and restore later
+		boolean zeroPad = this.settings.partCountZeroPadded;
+		this.settings.partCountZeroPadded = settings.partCountZeroPadded;
 
 		// Find all variables starting with $
 		Pattern regex = Pattern.compile("\\$[A-Za-z]+");
@@ -240,6 +258,8 @@ public class ExportFilenameTemplate
 				name = name.substring(0, match.first) + value + name.substring(match.second);
 			}
 		}
+		
+		this.settings.partCountZeroPadded = zeroPad;
 		
 		name += ".abc";
 		

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -52,6 +52,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.KeyStroke;
@@ -902,9 +903,13 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		midiPartsAndControls.add(partPanel, BorderLayout.CENTER);
 		midiPartsAndControls.add(playControlPanel, BorderLayout.SOUTH);
 		midiPartsAndControls.setBorder(BorderFactory.createTitledBorder("Part Settings"));
-
-		add(abcPartsAndSettings, "0, 0");
-		add(midiPartsAndControls, "1, 0");
+		
+		JSplitPane topLevelSplitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, abcPartsAndSettings, midiPartsAndControls);
+		topLevelSplitPane.setBorder(BorderFactory.createEmptyBorder());
+		topLevelSplitPane.setContinuousLayout(true);
+		topLevelSplitPane.setFocusable(false);
+		
+		add(topLevelSplitPane, "0, 0, 1, 0");
 		
 		final FileFilterDropListener dropListener = new FileFilterDropListener(false, "mid", "midi", "kar", "abc", "txt",
 				AbcSong.MSX_FILE_EXTENSION_NO_DOT);

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -395,7 +395,9 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 	
 	private JPanel createExportTemplatePanel()
 	{
-		JLabel patternLabel = new JLabel("<html><b><u>Pattern for ABC export filename</b></u></html>");
+		JLabel pageLabel = new JLabel("<html><b><u>ABC filename settings</b></u></html>");
+		
+		JLabel patternLabel = new JLabel("<html><b>Custom pattern for exported filename:</b></html>");
 		
 		JLabel whitespaceLabel = new JLabel("<html><b>Replace spaces in variables with:</b></html>");
 		
@@ -417,6 +419,15 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		replaceWhitespaceComboBox.addActionListener(e -> 
 		{
 			exportTemplateSettings.setWhitespaceReplaceText(ExportFilenameTemplate.spaceReplaceChars[replaceWhitespaceComboBox.getSelectedIndex()]);
+			updateExportFilenameExample();
+		});
+		
+		JCheckBox zeroPadPartCountCheckbox = new JCheckBox("Zero-pad part count to two digits");
+		zeroPadPartCountCheckbox.setSelected(exportTemplateSettings.isPartCountZeroPadded());
+		zeroPadPartCountCheckbox.addActionListener(e ->
+		{
+			boolean selected = zeroPadPartCountCheckbox.isSelected();
+			exportTemplateSettings.setPartCountZeroPadded(selected);
 			updateExportFilenameExample();
 		});
 
@@ -443,7 +454,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 			}
 		});
 		
-		JCheckBox enablePatternExportCheckBox = new JCheckBox("Enable pattern for ABC export filenames");
+		JCheckBox enablePatternExportCheckBox = new JCheckBox("Enable custom pattern for generating ABC filenames");
 		enablePatternExportCheckBox.setSelected(exportTemplateSettings.isExportFilenamePatternEnabled());
 		enablePatternExportCheckBox.addActionListener(e ->
 		{
@@ -451,6 +462,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 			exportTemplateSettings.setExportFilenamePatternEnabled(selected);
 			replaceWhitespaceComboBox.setEnabled(selected);
 			exportNameTextField.setEditable(selected);
+			zeroPadPartCountCheckbox.setEnabled(selected);
 		});
 		
 		exportTemplateExampleLabel = new JLabel(".abc");
@@ -470,7 +482,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		panel.setBorder(BorderFactory.createEmptyBorder(PAD, PAD, PAD, PAD));
 		
 		layout.insertRow(++row, PREFERRED);
-		panel.add(patternLabel, "0, " + row + ", 1, " + row);
+		panel.add(pageLabel, "0, " + row + ", 1, " + row);
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(enablePatternExportCheckBox, "0, " + row + ", 1, " + row);
@@ -478,6 +490,12 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		layout.insertRow(++row, PREFERRED);
 		panel.add(whitespaceLabel, "0, " + row);
 		panel.add(replaceWhitespaceComboBox, "1, " + row);
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(zeroPadPartCountCheckbox, "0, " + row + ", 1, " + row);
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(patternLabel, "0, " + row + ", 1, " + row);
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(exportNameTextField, "0, " + row + ", 1, " + row);
@@ -522,6 +540,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		exportTemplate.setMetadataSource(mockMetadata);
 
 		String exampleText = exportTemplate.formatName(exportTemplateSettings);
+		exampleText = "Example filename:  " + exampleText;
 		String exampleTextEllipsis = Util.ellipsis(exampleText, exportTemplateExampleLabel.getWidth(),
 				exportTemplateExampleLabel.getFont());
 

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -933,5 +933,10 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		public String getBadgerTitle() {
 			return "N: Title: "+getComposer()+" - "+getSongTitle();
 		}
+
+		@Override
+		public String getSourceFilename() {
+			return "Example Midi.mid";
+		}
 	}
 }


### PR DESCRIPTION
- Convert to using JSplitPane for part panel and midi panel to allow for resizing parts panel
- Rearrange menu items and tweak menu text in the ABC filename settings, to make the feature more intuitive
- Add ability to toggle zero-padding part count to two digits (6 vs 06)
- Add option to remove spaces from variables
- Add $SourceFile variable to export pattern