### PR TITLE
Import/export support for part numbering config

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -49,6 +49,10 @@ Version 2.5.0.117
 - Ability to customize instrument names for default part naming.
 - Option in section-editor to exclude notes with specified pan.
     For example it can be set to not play notes that are panned left.
+- Support for importing and exporting part numbering configurations.
+- Re-open settings at the same page if "reset page" was used.
+- Fix bug where "overwrite" confirmation for exporting drum maps would still overwrite if cancel was selected.
+- The msx filename for saving Maestro projects will be built from the ABC filename export pattern if it is enabled.
 
 Version 2.5.0.116
 - Added an Abc Merge Tool. It can takes multiple single-part ABC files and merge them into one multi-part ABC song.

--- a/src/com/digero/maestro/abc/PartNumberingConfig.java
+++ b/src/com/digero/maestro/abc/PartNumberingConfig.java
@@ -1,0 +1,121 @@
+package com.digero.maestro.abc;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+import com.digero.common.abc.LotroInstrument;
+import com.digero.common.util.ParseException;
+import com.digero.maestro.MaestroMain;
+
+public class PartNumberingConfig
+{
+	public int increment = -1;
+	public HashMap<LotroInstrument, Integer> firstPartMap = new HashMap<>();
+	
+	public PartNumberingConfig() {}
+	
+	public PartNumberingConfig(int increment, HashMap<LotroInstrument, Integer> firstPartMap)
+	{
+		this.increment = increment;
+		this.firstPartMap = firstPartMap;
+	}
+	
+	public void save(File outputFile) throws IOException
+	{
+		PrintStream out = new PrintStream(outputFile);
+		out.println("% Part Numbering Config");
+		out.println("% Created using " + MaestroMain.APP_NAME + " v" + MaestroMain.APP_VERSION);
+		out.println("% Format:");
+		out.println("% INCREMENT => [Increment Number (must be 1 or 10)]");
+		out.println("% [Instrument] => [First Part Number]");
+		out.println("% First part numbers are in the range 0 to 10 if INCREMENT is 10");
+		out.println("% Or in the range 0 to 999 if INCREMENT is 1");
+		out.println("% Comments begin with %");
+		out.println();
+		
+		out.println("INCREMENT => " + increment);
+		out.println();
+		for (LotroInstrument key : firstPartMap.keySet())
+		{
+			out.println(key.name() + " => " + firstPartMap.get(key));
+		}
+		out.close();
+	}
+	
+	public void load(File inputFile) throws IOException, ParseException
+	{
+		String fn = inputFile.getName();
+		FileInputStream inputStream = new FileInputStream(inputFile);
+		String line;
+		int lineNo = 0;
+		int increment = -1;
+		HashMap<LotroInstrument, Integer> map = new HashMap<LotroInstrument, Integer>();
+		
+		try (BufferedReader r = new BufferedReader(new InputStreamReader(inputStream)))
+		{
+			
+			while ((line = r.readLine()) != null)
+			{
+				lineNo++;
+				
+				int commentIndex = line.indexOf('%');
+				line = (commentIndex >= 0? line.substring(0, commentIndex) : line).trim();
+				if (line.isEmpty())
+					continue;
+				
+				StringTokenizer tokenizer = new StringTokenizer(line, " \t=>");
+				String key = tokenizer.nextToken();
+				String value = tokenizer.nextToken();
+				if (tokenizer.hasMoreTokens()) {
+					throw new ParseException("Invalid line (too many tokens)", fn, lineNo);
+				}
+				
+				LotroInstrument instrument = null;
+				for (LotroInstrument ins : LotroInstrument.values())
+				{
+					if (key.equals(ins.name()))
+					{
+						instrument = ins;
+					}
+				}
+				
+				if (instrument != null)
+				{
+					map.put(instrument, Integer.parseInt(value));
+				}
+				else if (key.equals("INCREMENT"))
+				{
+					increment = Integer.parseInt(value);
+					if (increment != 10 && increment != 1)
+					{
+						throw new ParseException("Invalid value of INCREMENT " + increment + ". Should be 1 or 10", fn, lineNo);
+					}
+				}
+			}
+			
+			if (increment == -1)
+			{
+				throw new ParseException("No INCREMENT value was found in config.", fn);
+			}
+			
+			for (LotroInstrument key : map.keySet())
+			{
+				int val = map.get(key);
+				if ((increment == 10 && (val < 0 || val > 10)) ||
+					(increment == 1 && (val < 0 || val > 999)))
+				{
+					throw new ParseException("Instrument " + key.name() + " has an out-of-range first part number " + val, fn);
+				}
+			}
+		}
+		
+		this.increment = increment;
+		this.firstPartMap = map;
+	}
+}

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1107,60 +1107,74 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 	private void doSettingsDialog(int tab)
 	{
-		SettingsDialog dialog = new SettingsDialog(ProjectFrame.this, partAutoNumberer,
-				partNameTemplate, exportFilenameTemplate, saveSettings.getCopy(), miscSettings.getCopy(), instrNameSettings.getCopy());
-		dialog.setActiveTab(tab);
-		dialog.setVisible(true);
-		if (dialog.isSuccess())
+		boolean showSettingsAgain = false;
+		int x = -1, y = -1;
+		do
 		{
-			if (dialog.isNumbererSettingsChanged())
+			showSettingsAgain = false;
+			SettingsDialog dialog = new SettingsDialog(ProjectFrame.this, partAutoNumberer,
+					partNameTemplate, exportFilenameTemplate, saveSettings.getCopy(), miscSettings.getCopy(), instrNameSettings.getCopy());
+			if (x > 0 && y > 0)
 			{
-				partAutoNumberer.setSettings(dialog.getNumbererSettings());
-				partAutoNumberer.renumberAllParts();
+				dialog.setLocation(x, y);
 			}
-			partNameTemplate.setSettings(dialog.getNameTemplateSettings());
-			partPanel.settingsChanged();
-			
-			exportFilenameTemplate.setSettings(dialog.getExportFilenameTemplateSettings());
-
-			instrNameSettings.copyFrom(dialog.getInstrNameSettings());
-			instrNameSettings.saveToPrefs();
-			
-			saveSettings.copyFrom(dialog.getSaveAndExportSettings());
-			saveSettings.saveToPrefs();
-			onSaveAndExportSettingsChanged();
-			
-			miscSettings.copyFrom(dialog.getMiscSettings());
-			miscSettings.saveToPrefs();
-		}
-		else if (dialog.isSettingPageReset())
-		{
-			switch(dialog.getResetPageIndex())
+			dialog.setActiveTab(tab);
+			dialog.setVisible(true);
+			if (dialog.isSuccess())
 			{
-			case 0: // part auto numberer
-				partAutoNumberer.restoreDefaultSettings();
-				partAutoNumberer.renumberAllParts();
-				break;
-			case 1: // part naming
-				partNameTemplate.restoreDefaultSettings();
+				if (dialog.isNumbererSettingsChanged())
+				{
+					partAutoNumberer.setSettings(dialog.getNumbererSettings());
+					partAutoNumberer.renumberAllParts();
+				}
+				partNameTemplate.setSettings(dialog.getNameTemplateSettings());
 				partPanel.settingsChanged();
-				break;
-			case 2: // file naming
-				exportFilenameTemplate.restoreDefaultSettings();
-				break;
-			case 3: // instr naming
-				instrNameSettings.restoreDefaults();
-				break;	
-			case 4: // save and export
-				saveSettings.restoreDefaults();
-				break;
-			case 5: // misc
-				miscSettings.restoreDefaults();
-				break;
+				
+				exportFilenameTemplate.setSettings(dialog.getExportFilenameTemplateSettings());
+
+				instrNameSettings.copyFrom(dialog.getInstrNameSettings());
+				instrNameSettings.saveToPrefs();
+
+				saveSettings.copyFrom(dialog.getSaveAndExportSettings());
+				saveSettings.saveToPrefs();
+				onSaveAndExportSettingsChanged();
+				
+				miscSettings.copyFrom(dialog.getMiscSettings());
+				miscSettings.saveToPrefs();
 			}
-		}
-		currentSettingsDialogTab = dialog.getActiveTab();
-		dialog.dispose();
+			else if (dialog.isSettingPageReset())
+			{
+				tab = dialog.getResetPageIndex();
+				switch(tab)
+				{
+				case 0: // part auto numberer
+					partAutoNumberer.restoreDefaultSettings();
+					partAutoNumberer.renumberAllParts();
+					break;
+				case 1: // part naming
+					partNameTemplate.restoreDefaultSettings();
+					partPanel.settingsChanged();
+					break;
+				case 2: // file naming
+					exportFilenameTemplate.restoreDefaultSettings();
+					break;
+				case 3: // instr naming
+					instrNameSettings.restoreDefaults();
+					break;	
+				case 4: // save and export
+					saveSettings.restoreDefaults();
+					break;
+				case 5: // misc
+					miscSettings.restoreDefaults();
+					break;
+				}
+				showSettingsAgain = true;
+				x = dialog.getLocation().x;
+				y = dialog.getLocation().y;
+			}
+			currentSettingsDialogTab = dialog.getActiveTab();
+			dialog.dispose();
+		} while (showSettingsAgain);
 	}
 
 	private void onSaveAndExportSettingsChanged()

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2423,7 +2423,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		File saveFile = abcSong.getSaveFile();
 		File allowOverwriteFile = allowOverwriteSaveFile ? saveFile : null;
 
-		if (saveFile == null)
+		if (saveFile == null || exportFilenameTemplate.isEnabled())
 		{
 			String defaultFolder;
 			if (abcSong.getExportFile() != null)
@@ -2434,14 +2434,23 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			String folder = prefs.get("saveDialogFolder", defaultFolder);
 			if (!new File(folder).exists())
 				folder = defaultFolder;
+			
+			String fileName = "mySong.msx";
+			
+			if (exportFilenameTemplate.isEnabled())
+			{
+				fileName = exportFilenameTemplate.formatName();
+			}
+			else
+			{
+				saveFile = abcSong.getExportFile();
+				if (saveFile == null)
+					saveFile = abcSong.getSourceFile();
+				if (saveFile == null)
+					saveFile = new File(folder, abcSong.getSequenceInfo().getFileName());
+				fileName = saveFile.getName();
+			}
 
-			saveFile = abcSong.getExportFile();
-			if (saveFile == null)
-				saveFile = abcSong.getSourceFile();
-			if (saveFile == null)
-				saveFile = new File(folder, abcSong.getSequenceInfo().getFileName());
-
-			String fileName = saveFile.getName();
 			int dot = fileName.lastIndexOf('.');
 			if (dot > 0)
 				fileName = fileName.substring(0, dot);

--- a/src/com/digero/maestro/view/TrackPanel.java
+++ b/src/com/digero/maestro/view/TrackPanel.java
@@ -751,24 +751,29 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				DrumNoteMap.FILE_SUFFIX));
 
 		File saveFile;
-		if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
-			return false;
-
-		saveFile = fileChooser.getSelectedFile();
-
-		if (saveFile.getName().indexOf('.') < 0)
+		do
 		{
-			saveFile = new File(saveFile.getParentFile(), saveFile.getName() + "." + DrumNoteMap.FILE_SUFFIX);
-		}
-
-		if (saveFile.exists())
-		{
-			int result = JOptionPane.showConfirmDialog(this, "File " + saveFile.getName()
-					+ " already exists. Overwrite?", "Confirm overwrite", JOptionPane.OK_CANCEL_OPTION);
-			if (result != JOptionPane.OK_OPTION)
+			if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
 				return false;
-		}
 
+			saveFile = fileChooser.getSelectedFile();
+
+			if (saveFile.getName().indexOf('.') < 0)
+			{
+				saveFile = new File(saveFile.getParentFile(), saveFile.getName() + "." + DrumNoteMap.FILE_SUFFIX);
+			}
+
+			if (saveFile.exists())
+			{
+				int result = JOptionPane.showConfirmDialog(this, "File " + saveFile.getName()
+						+ " already exists. Overwrite?", "Confirm overwrite", JOptionPane.OK_CANCEL_OPTION);
+				if (result != JOptionPane.OK_OPTION)
+					continue;
+			}
+			
+			break;
+		} while (true);
+		
 		try
 		{
 			abcPart.getDrumMap(trackInfo.getTrackNumber()).save(saveFile);

--- a/src/com/digero/maestro/view/TrackPanel.java
+++ b/src/com/digero/maestro/view/TrackPanel.java
@@ -751,26 +751,23 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				DrumNoteMap.FILE_SUFFIX));
 
 		File saveFile;
-		do
+		if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
+			return false;
+
+		saveFile = fileChooser.getSelectedFile();
+
+		if (saveFile.getName().indexOf('.') < 0)
 		{
-			if (fileChooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
+			saveFile = new File(saveFile.getParentFile(), saveFile.getName() + "." + DrumNoteMap.FILE_SUFFIX);
+		}
+
+		if (saveFile.exists())
+		{
+			int result = JOptionPane.showConfirmDialog(this, "File " + saveFile.getName()
+					+ " already exists. Overwrite?", "Confirm overwrite", JOptionPane.OK_CANCEL_OPTION);
+			if (result != JOptionPane.OK_OPTION)
 				return false;
-
-			saveFile = fileChooser.getSelectedFile();
-
-			if (saveFile.getName().indexOf('.') < 0)
-			{
-				saveFile = new File(saveFile.getParentFile(), saveFile.getName() + "." + DrumNoteMap.FILE_SUFFIX);
-			}
-
-			if (saveFile.exists())
-			{
-				int result = JOptionPane.showConfirmDialog(this, "File " + saveFile.getName()
-						+ " already exists. Overwrite?", "Confirm overwrite", JOptionPane.OK_CANCEL_OPTION);
-				if (result != JOptionPane.OK_OPTION)
-					continue;
-			}
-		} while (false);
+		}
 
 		try
 		{


### PR DESCRIPTION
- Support importing and exporting part numbering configurations
- Fix bug where "overwrite" dialog for exporting drum map would overwrite even if cancel was selected
- Re-open settings at the same page if "reset page" was used
- Regenerate msx filename based on export ABC pattern if pattern is enabled