### PR TITLE
Add option to control filename regeneration, change default theme

### DIFF
--- a/src/com/digero/maestro/abc/ExportFilenameTemplate.java
+++ b/src/com/digero/maestro/abc/ExportFilenameTemplate.java
@@ -23,6 +23,7 @@ public class ExportFilenameTemplate
 	public static class Settings
 	{
 		private boolean exportFilenamePatternEnabled;
+		private boolean alwaysRegenerateFromPattern;
 		private String exportFilenamePattern;
 		private String whitespaceReplaceText;
 		private boolean partCountZeroPadded;
@@ -33,6 +34,7 @@ public class ExportFilenameTemplate
 		{
 			this.prefs = prefs;
 			exportFilenamePatternEnabled = prefs.getBoolean("exportFilenamePatternEnabled", false);
+			alwaysRegenerateFromPattern = prefs.getBoolean("alwaysRegenerateFromPattern", false);
 			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount - $SongTitle");
 			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
 			partCountZeroPadded = prefs.getBoolean("partCountZeroPadded", true);
@@ -47,6 +49,7 @@ public class ExportFilenameTemplate
 		private void save()
 		{
 			prefs.putBoolean("exportFilenamePatternEnabled", exportFilenamePatternEnabled);
+			prefs.putBoolean("alwaysRegenerateFromPattern", alwaysRegenerateFromPattern);
 			prefs.put("exportFilenamePattern", exportFilenamePattern);
 			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
 			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
@@ -55,6 +58,7 @@ public class ExportFilenameTemplate
 		private void copyFrom(Settings source)
 		{
 			this.exportFilenamePatternEnabled = source.exportFilenamePatternEnabled;
+			this.alwaysRegenerateFromPattern = source.alwaysRegenerateFromPattern;
 			this.exportFilenamePattern = source.exportFilenamePattern;
 			this.whitespaceReplaceText = source.whitespaceReplaceText;
 			this.partCountZeroPadded = source.partCountZeroPadded;
@@ -68,6 +72,16 @@ public class ExportFilenameTemplate
 		public void setExportFilenamePatternEnabled(boolean exportFilenamePatternEnabled)
 		{
 			this.exportFilenamePatternEnabled = exportFilenamePatternEnabled;
+		}
+		
+		public boolean shouldAlwaysRegenerateFromPattern()
+		{
+			return alwaysRegenerateFromPattern;
+		}
+		
+		public void setAlwaysRegenerateFromPattern(boolean alwaysRegenerateFromPattern)
+		{
+			this.alwaysRegenerateFromPattern = alwaysRegenerateFromPattern;
 		}
 
 		public String getExportFilenamePattern()
@@ -227,6 +241,11 @@ public class ExportFilenameTemplate
 	public boolean isEnabled()
 	{
 		return settings.isExportFilenamePatternEnabled();
+	}
+	
+	public boolean shouldRegenerateFilename()
+	{
+		return settings.isExportFilenamePatternEnabled() && settings.shouldAlwaysRegenerateFromPattern();
 	}
 
 	public String formatName()

--- a/src/com/digero/maestro/view/MiscSettings.java
+++ b/src/com/digero/maestro/view/MiscSettings.java
@@ -9,7 +9,7 @@ public class MiscSettings
 	public boolean showMaxPolyphony = true;
 	public boolean showBadger = false;
 	public boolean allBadger = false;
-	public String theme = "Default";
+	public String theme = "Flat Light";
 	public int fontSize = 12;
 	
 	private final Preferences prefs;

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2317,7 +2317,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		File exportFile = abcSong.getExportFile();
 		File allowOverwriteFile = allowOverwriteExportFile ? exportFile : null;
 
-		if (exportFile == null || exportFilenameTemplate.isEnabled())
+		if (exportFile == null || exportFilenameTemplate.shouldRegenerateFilename())
 		{
 			String defaultFolder = Util.getLotroMusicPath(false).getAbsolutePath();
 			String folder = prefs.get("exportDialogFolder", defaultFolder);
@@ -2437,7 +2437,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		File saveFile = abcSong.getSaveFile();
 		File allowOverwriteFile = allowOverwriteSaveFile ? saveFile : null;
 
-		if (saveFile == null || exportFilenameTemplate.isEnabled())
+		if (saveFile == null || exportFilenameTemplate.shouldRegenerateFilename())
 		{
 			String defaultFolder;
 			if (abcSong.getExportFile() != null)

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -163,7 +163,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		tabPanel = new JTabbedPane();
 		tabPanel.addTab("ABC Part Numbering", createNumberingPanel()); // NUMBERING_TAB
 		tabPanel.addTab("ABC Part Naming", createNameTemplatePanel()); // NAME_TEMPLATE_TAB
-		tabPanel.addTab("ABC File Naming", createExportTemplatePanel());
+		tabPanel.addTab("File Naming", createExportTemplatePanel());
 		tabPanel.addTab("Instrument names", createInstrNamePanel());
 		tabPanel.addTab("Save & Export", createSaveAndExportSettingsPanel()); // SAVE_EXPORT_TAB
 		tabPanel.addTab("Misc", createMiscPanel()); // MISC_TAB
@@ -624,7 +624,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 	
 	private JPanel createExportTemplatePanel()
 	{
-		JLabel pageLabel = new JLabel("<html><b><u>ABC filename settings</b></u></html>");
+		JLabel pageLabel = new JLabel("<html><b><u>ABC and MSX filename settings</b></u></html>");
 		
 		JLabel patternLabel = new JLabel("<html><b>Custom pattern for exported filename:</b></html>");
 		
@@ -683,7 +683,16 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 			}
 		});
 		
-		JCheckBox enablePatternExportCheckBox = new JCheckBox("Enable custom pattern for generating ABC filenames");
+		JCheckBox alwaysRegenerateCheckBox = new JCheckBox("Always regenerate filenames using pattern, even if a filename exists");
+		alwaysRegenerateCheckBox.setSelected(exportTemplateSettings.shouldAlwaysRegenerateFromPattern());
+		alwaysRegenerateCheckBox.setEnabled(exportTemplateSettings.isExportFilenamePatternEnabled());
+		alwaysRegenerateCheckBox.addActionListener(e ->
+		{
+			boolean selected = alwaysRegenerateCheckBox.isSelected();
+			exportTemplateSettings.setAlwaysRegenerateFromPattern(selected);
+		});
+		
+		JCheckBox enablePatternExportCheckBox = new JCheckBox("Enable custom pattern for generating filenames");
 		enablePatternExportCheckBox.setSelected(exportTemplateSettings.isExportFilenamePatternEnabled());
 		enablePatternExportCheckBox.addActionListener(e ->
 		{
@@ -692,6 +701,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 			replaceWhitespaceComboBox.setEnabled(selected);
 			exportNameTextField.setEditable(selected);
 			zeroPadPartCountCheckbox.setEnabled(selected);
+			alwaysRegenerateCheckBox.setEnabled(selected);
 		});
 		
 		exportTemplateExampleLabel = new JLabel(".abc");
@@ -715,6 +725,9 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(enablePatternExportCheckBox, "0, " + row + ", 1, " + row);
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(alwaysRegenerateCheckBox, "0, " + row + ", 1, " + row);
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(whitespaceLabel, "0, " + row);


### PR DESCRIPTION
- Add option to control filename regeneration (regeneration disabled by default)
- Rename some of the export filename menu items (feature works for both MSX and ABC)
- Change default theme to Flat Light