### PR TITLE
MSX/ABC filename generation precedence

### DIFF
--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2284,36 +2284,47 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 		File exportFile = abcSong.getExportFile();
 		File allowOverwriteFile = allowOverwriteExportFile ? exportFile : null;
+		
+		String defaultFolder = Util.getLotroMusicPath(false).getAbsolutePath();
+		String folder = prefs.get("exportDialogFolder", defaultFolder);
+		if (!new File(folder).exists())
+			folder = defaultFolder;
+		
+		String fileName = "mySong.abc";
 
-		if (exportFile == null || exportFilenameTemplate.shouldRegenerateFilename()) {
-			String defaultFolder = Util.getLotroMusicPath(false).getAbsolutePath();
-			String folder = prefs.get("exportDialogFolder", defaultFolder);
-			if (!new File(folder).exists())
-				folder = defaultFolder;
-
-			String fileName = "mySong.abc";
-
-			if (exportFilenameTemplate.isEnabled()) {
-				fileName = exportFilenameTemplate.formatName();
-			} else {
-				exportFile = abcSong.getSourceFile();
-				if (exportFile == null) {
-					fileName = abcSong.getSequenceInfo().getFileName();
-				} else {
-					fileName = exportFile.getName();
-				}
-			}
-
-			int dot = fileName.lastIndexOf('.');
-			if (dot > 0)
-				fileName = fileName.substring(0, dot);
-			else if (dot == 0)
-				fileName = "";
-			fileName = StringCleaner.cleanForFileName(fileName);
-			fileName += ".abc";
-
-			exportFile = new File(folder, fileName);
+		if (exportFilenameTemplate.shouldRegenerateFilename())
+		{
+			fileName = exportFilenameTemplate.formatName();
 		}
+		else if (exportFile == null)
+		{
+			System.out.println("here1");
+			exportFile = abcSong.getSourceFile();
+			
+			if (exportFile == null && exportFilenameTemplate.isEnabled())
+			{
+				fileName = exportFilenameTemplate.formatName();
+			}
+			
+			if (exportFile == null)
+			{
+				fileName = abcSong.getSequenceInfo().getFileName();
+			}
+			else
+			{
+				fileName = exportFile.getName(); 
+			}
+		}
+		
+		int dot = fileName.lastIndexOf('.');
+		if (dot > 0)
+			fileName = fileName.substring(0, dot);
+		else if (dot == 0)
+			fileName = "";
+		fileName = StringCleaner.cleanForFileName(fileName);
+		fileName += ".abc";
+
+		exportFile = new File(folder, fileName);
 
 		exportFile = doSaveDialog(exportFile, allowOverwriteFile, ".abc",
 				new ExtensionFileFilter("ABC files (*.abc, *.txt)", "abc", "txt"));
@@ -2386,38 +2397,42 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 		File saveFile = abcSong.getSaveFile();
 		File allowOverwriteFile = allowOverwriteSaveFile ? saveFile : null;
+		
+		String defaultFolder;
+		if (abcSong.getExportFile() != null)
+			defaultFolder = abcSong.getExportFile().getAbsoluteFile().getParent();
+		else
+			defaultFolder = Util.getLotroMusicPath(false).getAbsolutePath();
 
-		if (saveFile == null || exportFilenameTemplate.shouldRegenerateFilename()) {
-			String defaultFolder;
-			if (abcSong.getExportFile() != null)
-				defaultFolder = abcSong.getExportFile().getAbsoluteFile().getParent();
-			else
-				defaultFolder = Util.getLotroMusicPath(false).getAbsolutePath();
+		String folder = prefs.get("saveDialogFolder", defaultFolder);
+		if (!new File(folder).exists())
+			folder = defaultFolder;
+		
+		String fileName = "mySong.msx";
 
-			String folder = prefs.get("saveDialogFolder", defaultFolder);
-			if (!new File(folder).exists())
-				folder = defaultFolder;
-
-			String fileName = "mySong.msx";
-
-			if (exportFilenameTemplate.isEnabled()) {
-				fileName = exportFilenameTemplate.formatName();
-			} else {
-				saveFile = abcSong.getExportFile();
-				if (saveFile == null)
-					saveFile = abcSong.getSourceFile();
-				if (saveFile == null)
-					saveFile = new File(folder, abcSong.getSequenceInfo().getFileName());
-				fileName = saveFile.getName();
-			}
-
-			int dot = fileName.lastIndexOf('.');
-			if (dot > 0)
-				fileName = fileName.substring(0, dot);
-			fileName += AbcSong.MSX_FILE_EXTENSION;
-
-			saveFile = new File(folder, fileName);
+		if (exportFilenameTemplate.shouldRegenerateFilename())
+		{
+			fileName = exportFilenameTemplate.formatName();
 		}
+		else if (saveFile == null)
+		{
+			saveFile = abcSong.getExportFile();
+			if (saveFile == null && exportFilenameTemplate.isEnabled())
+				saveFile = new File(folder, exportFilenameTemplate.formatName());
+			if (saveFile == null)
+				saveFile = abcSong.getSourceFile();
+			if (saveFile == null)
+				saveFile = new File(folder, abcSong.getSequenceInfo().getFileName());
+
+			fileName = saveFile.getName();
+		}
+		
+		int dot = fileName.lastIndexOf('.');
+		if (dot > 0)
+			fileName = fileName.substring(0, dot);
+		fileName += AbcSong.MSX_FILE_EXTENSION;
+
+		saveFile = new File(folder, fileName);
 
 		saveFile = doSaveDialog(saveFile, allowOverwriteFile, AbcSong.MSX_FILE_EXTENSION,
 				new ExtensionFileFilter(AbcSong.MSX_FILE_DESCRIPTION_PLURAL + " (*" + AbcSong.MSX_FILE_EXTENSION + ")",

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2292,28 +2292,26 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		
 		String fileName = "mySong.abc";
 
+		// Always regenerate setting from pattern export is highest precedent
 		if (exportFilenameTemplate.shouldRegenerateFilename())
 		{
 			fileName = exportFilenameTemplate.formatName();
 		}
-		else if (exportFile == null)
+		else if (exportFile != null) // else use abc filename if exists already
 		{
-			System.out.println("here1");
-			exportFile = abcSong.getSourceFile();
-			
-			if (exportFile == null && exportFilenameTemplate.isEnabled())
-			{
-				fileName = exportFilenameTemplate.formatName();
-			}
-			
-			if (exportFile == null)
-			{
-				fileName = abcSong.getSequenceInfo().getFileName();
-			}
-			else
-			{
-				fileName = exportFile.getName(); 
-			}
+			fileName = exportFile.getName();
+		}
+		else if (abcSong.getSaveFile() != null) // else use msx filename if exists already
+		{
+			fileName = abcSong.getSaveFile().getName();
+		}
+		else if (exportFilenameTemplate.isEnabled()) // else use pattern if usage is enabled
+		{
+			fileName = exportFilenameTemplate.formatName();
+		}
+		else if (abcSong.getSourceFile() != null) // else default to source file (midi/abc)
+		{
+			fileName = abcSong.getSourceFilename();
 		}
 		
 		int dot = fileName.lastIndexOf('.');
@@ -2410,21 +2408,26 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		
 		String fileName = "mySong.msx";
 
+		// Always regenerate setting from pattern export is highest precedent
 		if (exportFilenameTemplate.shouldRegenerateFilename())
 		{
 			fileName = exportFilenameTemplate.formatName();
 		}
-		else if (saveFile == null)
+		else if (saveFile != null) // else use MSX file if exists already
 		{
-			saveFile = abcSong.getExportFile();
-			if (saveFile == null && exportFilenameTemplate.isEnabled())
-				saveFile = new File(folder, exportFilenameTemplate.formatName());
-			if (saveFile == null)
-				saveFile = abcSong.getSourceFile();
-			if (saveFile == null)
-				saveFile = new File(folder, abcSong.getSequenceInfo().getFileName());
-
 			fileName = saveFile.getName();
+		}
+		else if (abcSong.getExportFile() != null) // else use ABC filename if exists
+		{
+			fileName = abcSong.getExportFile().getName();
+		}
+		else if (exportFilenameTemplate.isEnabled()) // else use pattern if enabled
+		{
+			fileName = exportFilenameTemplate.formatName();
+		}
+		else if (abcSong.getSourceFile() != null) // else use source (midi/abc) file
+		{
+			fileName = abcSong.getSourceFilename();
 		}
 		
 		int dot = fileName.lastIndexOf('.');

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -639,19 +639,25 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants {
 				updateExportFilenameExample();
 			}
 		});
-
-		JCheckBox alwaysRegenerateCheckBox = new JCheckBox(
-				"Always regenerate filenames using pattern, even if a filename exists");
+		
+		JCheckBox alwaysRegenerateCheckBox = new JCheckBox("Always regenerate filenames using pattern");
 		alwaysRegenerateCheckBox.setSelected(exportTemplateSettings.shouldAlwaysRegenerateFromPattern());
 		alwaysRegenerateCheckBox.setEnabled(exportTemplateSettings.isExportFilenamePatternEnabled());
-		alwaysRegenerateCheckBox.addActionListener(e -> {
+		alwaysRegenerateCheckBox.setToolTipText("<html>Enable this setting to have Maestro always freshly generate filenames using the pattern.<br>"
+				+ "Disable this setting to have Maestro use a filename from a previous export, if available.</html>");
+		alwaysRegenerateCheckBox.addActionListener(e ->
+		{
 			boolean selected = alwaysRegenerateCheckBox.isSelected();
 			exportTemplateSettings.setAlwaysRegenerateFromPattern(selected);
 		});
 
 		JCheckBox enablePatternExportCheckBox = new JCheckBox("Enable custom pattern for generating filenames");
 		enablePatternExportCheckBox.setSelected(exportTemplateSettings.isExportFilenamePatternEnabled());
-		enablePatternExportCheckBox.addActionListener(e -> {
+		enablePatternExportCheckBox.setToolTipText("<html>Select to enable filename generation using patterns.<br>"
+				+ "Define the pattern in the text box below, referencing any variables in the variable list.<br>"
+				+ "An example filename generated from your pattern is shown below the text box.</html>");
+		enablePatternExportCheckBox.addActionListener(e ->
+		{
 			boolean selected = enablePatternExportCheckBox.isSelected();
 			exportTemplateSettings.setExportFilenamePatternEnabled(selected);
 			replaceWhitespaceComboBox.setEnabled(selected);


### PR DESCRIPTION
for saving as msx:
 - if pattern generation and always regenerate are enabled, use pattern
 - else if prior msx file exists, use it (saveFile)
 - else if prior abc file exists, use it (exportFile)
 - else if pattern generation was enabled, use pattern
 - else use midi filename (sourceFile)

for exporting abc:
 - if pattern generation and always regenerate are enabled, use pattern
 - else if prior abc file exists, use it (exportFile)
 - else if msx file exists, use it (saveFile)
 - else if pattern enabled, use it
 - else use midi filename (sourceFile)