### PR TITLE
Section/Tune layout fix

### DIFF
--- a/src/com/digero/common/view/PatchedJScrollPane.java
+++ b/src/com/digero/common/view/PatchedJScrollPane.java
@@ -1,0 +1,21 @@
+package com.digero.common.view;
+
+import java.awt.Component;
+import java.awt.Dimension;
+
+import javax.swing.JScrollPane;
+
+@SuppressWarnings("serial")
+public class PatchedJScrollPane extends JScrollPane {
+	
+	@Override
+	public Dimension getPreferredSize() {
+		Dimension d = super.getPreferredSize();
+		d.width = d.width + new JScrollPane().getVerticalScrollBar().getPreferredSize().width;
+		return d;
+	}
+	
+	public PatchedJScrollPane(Component component) {
+		super(component);
+	}
+}

--- a/src/com/digero/maestro/view/SectionEditor.java
+++ b/src/com/digero/maestro/view/SectionEditor.java
@@ -2,9 +2,7 @@ package com.digero.maestro.view;
 
 import static javax.swing.SwingConstants.CENTER;
 
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
+import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Window;
 import java.awt.event.ActionListener;
@@ -15,6 +13,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import javax.swing.BorderFactory;
 import javax.swing.ButtonModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -23,17 +22,18 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 
 import com.digero.common.util.Listener;
+import com.digero.common.view.PatchedJScrollPane;
 import com.digero.maestro.abc.AbcPart;
 import com.digero.maestro.abc.AbcPartEvent;
+import com.digero.maestro.abc.AbcPartEvent.AbcPartProperty;
 import com.digero.maestro.abc.AbcSongEvent;
 import com.digero.maestro.abc.PartSection;
-import com.digero.maestro.abc.AbcPartEvent.AbcPartProperty;
 
 import info.clearthought.layout.TableLayout;
 
@@ -104,17 +104,19 @@ public class SectionEditor {
 					}
 				});
 
-				int rowHeight = 16;
-				int auxHeight = 24;
-				Font font = UIManager.getFont("defaultFont");
-				Graphics graphics = jf.getGraphics();
-				if (font != null && graphics != null) // Using a flat theme - resize panel based on text size
-				{
-					FontMetrics metrics = graphics.getFontMetrics(font);
-					int fontHeight = metrics.getHeight();
-					rowHeight = fontHeight + Math.max(4, (int) (fontHeight * 0.3));
-					auxHeight = (int) (rowHeight * 1.5);
-				}
+				double rowHeight = TableLayout.PREFERRED;
+				double auxHeight = TableLayout.PREFERRED;
+//				int rowHeight = 16;
+//				int auxHeight = 24;
+//				Font font = UIManager.getFont("defaultFont");
+//				Graphics graphics = jf.getGraphics();
+//				if (font != null && graphics != null) // Using a flat theme - resize panel based on text size
+//				{
+//					FontMetrics metrics = graphics.getFontMetrics(font);
+//					int fontHeight = metrics.getHeight();
+//					rowHeight = fontHeight + Math.max(4, (int) (fontHeight * 0.3));
+//					auxHeight = (int) (rowHeight * 1.5);
+//				}
 
 				JPanel panel = new JPanel();
 
@@ -150,9 +152,11 @@ public class SectionEditor {
 				 */
 				TableLayout layout = new TableLayout(LAYOUT_COLS, LAYOUT_ROWS);
 				int vg = layout.getVGap();
-				int w = 34 * rowHeight;
-				int h = (numberOfSections + 1) * rowHeight + 5 * auxHeight + (4 + numberOfSections) * vg + rowHeight;
-				this.setSize(w, h);
+//				int w = 34 * rowHeight;
+//				int h = (numberOfSections + 1) * rowHeight + 5 * auxHeight + (4 + numberOfSections) * vg + rowHeight;
+//				int w = 1200;
+//				int h = 900;
+//				this.setSize(w, h);
 
 				panel.setLayout(new TableLayout(LAYOUT_COLS, LAYOUT_ROWS));
 
@@ -203,6 +207,10 @@ public class SectionEditor {
 						+ (firstRowIndex + numberOfSections) + ", f, f");
 				// panel.add(new JLabel("Rest of the track"), "1, "+(3+numberOfSections)+", 2, "+(3+numberOfSections)+",
 				// c, c");
+				
+				panel.revalidate();
+				Dimension sz = panel.getPreferredSize();
+				System.out.println("w: " + sz.width + " h: " + sz.height);
 
 				for (int j = 0; j < numberOfSections; j++) {
 					SectionEditorLine l = new SectionEditorLine();
@@ -495,14 +503,18 @@ public class SectionEditor {
 				 * +(10+numberOfSections)+", c, c"); panel.add(new JLabel("notes that is not covered by sections."),
 				 * "7, "+(11+numberOfSections)+", 10," +(11+numberOfSections)+", c, c");
 				 */
+				
+				PatchedJScrollPane scrollPane = new PatchedJScrollPane(panel);
+				scrollPane.setViewportBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-				this.getContentPane().add(panel);
+				this.getContentPane().add(scrollPane);
+				this.pack();
 				Window window = SwingUtilities.windowForComponent(this);
 				if (window != null) {
 					// Lets keep the dialog inside the screen, in case the screen changed resolution since it was last
 					// popped up
-					int maxX = window.getBounds().width - w;
-					int maxY = window.getBounds().height - h;
+					int maxX = window.getBounds().width - this.getWidth();
+					int maxY = window.getBounds().height - this.getHeight();
 					int x = Math.max(0, Math.min(maxX, SectionEditor.lastLocation.x));
 					int y = Math.max(0, Math.min(maxY, SectionEditor.lastLocation.y));
 					this.setLocation(new Point(x, y));

--- a/src/com/digero/maestro/view/SectionEditor.java
+++ b/src/com/digero/maestro/view/SectionEditor.java
@@ -22,7 +22,6 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
@@ -151,7 +150,7 @@ public class SectionEditor {
 				 * 
 				 */
 				TableLayout layout = new TableLayout(LAYOUT_COLS, LAYOUT_ROWS);
-				int vg = layout.getVGap();
+//				int vg = layout.getVGap();
 //				int w = 34 * rowHeight;
 //				int h = (numberOfSections + 1) * rowHeight + 5 * auxHeight + (4 + numberOfSections) * vg + rowHeight;
 //				int w = 1200;

--- a/src/com/digero/maestro/view/SectionEditorLine.java
+++ b/src/com/digero/maestro/view/SectionEditorLine.java
@@ -16,4 +16,31 @@ class SectionEditorLine {
 	JCheckBox doubling1 = new JCheckBox();
 	JCheckBox doubling2 = new JCheckBox();
 	JCheckBox doubling3 = new JCheckBox();
+	
+//	private JCheckBox enable = new JCheckBox();
+//	private JTextField barA = new JTextField("0");
+//	private JTextField barB = new JTextField("0");
+//	private JTextField transpose = new JTextField("0");
+//	private JTextField velo = new JTextField("0");
+//	private JCheckBox silent = new JCheckBox();
+//	private JCheckBox resetVelocities = new JCheckBox();
+//	private JTextField fade = new JTextField("0");
+//	private JCheckBox doubling0 = new JCheckBox();
+//	private JCheckBox doubling1 = new JCheckBox();
+//	private JCheckBox doubling2 = new JCheckBox();
+//	private JCheckBox doubling3 = new JCheckBox();
+	
+//	boolean isPercussion = false;
+//	boolean isRestOfTrack = false;
+	
+//	public SectionEditorLine(boolean isPercussion, boolean isRestOfTrack) {
+//		this.isPercussion = isPercussion;
+//		this.isRestOfTrack = isRestOfTrack;
+//		
+//		transpose.setEnabled(!isPercussion);
+//		doubling0.setEnabled(!isPercussion);
+//		doubling1.setEnabled(!isPercussion);
+//		doubling2.setEnabled(!isPercussion);
+//		doubling3.setEnabled(!isPercussion);
+//	}
 }

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -2,9 +2,6 @@ package com.digero.maestro.view;
 
 import static javax.swing.SwingConstants.CENTER;
 
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Window;
 import java.awt.event.ActionListener;
@@ -16,18 +13,20 @@ import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 
 import com.digero.common.util.Listener;
+import com.digero.common.view.PatchedJScrollPane;
 import com.digero.maestro.abc.AbcSong;
 import com.digero.maestro.abc.AbcSongEvent;
 import com.digero.maestro.abc.TuneLine;
@@ -82,17 +81,19 @@ public class TuneEditor {
 						openDialog = null;
 					}
 				});
-				int rowHeight = 16;
-				int auxHeight = 24;
-				Font font = UIManager.getFont("defaultFont");
-				Graphics graphics = jf.getGraphics();
-				if (font != null && graphics != null) // Using a flat theme - resize panel based on text size
-				{
-					FontMetrics metrics = graphics.getFontMetrics(font);
-					int fontHeight = metrics.getHeight();
-					rowHeight = fontHeight + Math.max(4, (int) (fontHeight * 0.3));
-					auxHeight = (int) (rowHeight * 1.5);
-				}
+				double rowHeight = TableLayout.PREFERRED;
+				double auxHeight = TableLayout.PREFERRED;
+//				int rowHeight = 16;
+//				int auxHeight = 24;
+//				Font font = UIManager.getFont("defaultFont");
+//				Graphics graphics = jf.getGraphics();
+//				if (font != null && graphics != null) // Using a flat theme - resize panel based on text size
+//				{
+//					FontMetrics metrics = graphics.getFontMetrics(font);
+//					int fontHeight = metrics.getHeight();
+//					rowHeight = fontHeight + Math.max(4, (int) (fontHeight * 0.3));
+//					auxHeight = (int) (rowHeight * 1.5);
+//				}
 
 				JPanel panel = new JPanel();
 
@@ -119,11 +120,11 @@ public class TuneEditor {
 
 				TableLayout layout = new TableLayout(LAYOUT_COLS, LAYOUT_ROWS);
 				int vg = layout.getVGap();
-				int w = 25 * rowHeight;
-				// int h = 153+(rowHeight+0)*SectionEditor.numberOfSections;
-				int h = (SectionEditor.numberOfSections) * rowHeight + 4 * auxHeight
-						+ (3 + SectionEditor.numberOfSections) * vg;
-				this.setSize(w, h);
+//				int w = 25 * rowHeight;
+//				// int h = 153+(rowHeight+0)*SectionEditor.numberOfSections;
+//				int h = (SectionEditor.numberOfSections) * rowHeight + 4 * auxHeight
+//						+ (3 + SectionEditor.numberOfSections) * vg;
+//				this.setSize(w, h);
 
 				panel.setLayout(layout);
 				// panel.add(new JLabel("<html><b> " + abcSong.getTitle() + "</html>"), "0, 0,
@@ -236,13 +237,17 @@ public class TuneEditor {
 				 * panel.add(warn3, "0," +(13+SectionEditor.numberOfSections)+", 4,"
 				 * +(13+SectionEditor.numberOfSections)+", c, c");
 				 */
-				this.getContentPane().add(panel);
+
+				PatchedJScrollPane scrollPane = new PatchedJScrollPane(panel);
+				scrollPane.setViewportBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+				this.getContentPane().add(scrollPane);
+				this.pack();
 				Window window = SwingUtilities.windowForComponent(this);
 				if (window != null) {
 					// Lets keep the dialog inside the screen, in case the screen changed resolution
 					// since it was last popped up
-					int maxX = window.getBounds().width - w;
-					int maxY = window.getBounds().height - h;
+					int maxX = window.getBounds().width - this.getWidth();
+					int maxY = window.getBounds().height - this.getHeight();
 					int x = Math.max(0, Math.min(maxX, TuneEditor.lastLocation.x));
 					int y = Math.max(0, Math.min(maxY, TuneEditor.lastLocation.y));
 					this.setLocation(new Point(x, y));

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -20,7 +20,6 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
@@ -82,7 +81,7 @@ public class TuneEditor {
 					}
 				});
 				double rowHeight = TableLayout.PREFERRED;
-				double auxHeight = TableLayout.PREFERRED;
+//				double auxHeight = TableLayout.PREFERRED;
 //				int rowHeight = 16;
 //				int auxHeight = 24;
 //				Font font = UIManager.getFont("defaultFont");
@@ -119,7 +118,7 @@ public class TuneEditor {
 				 */
 
 				TableLayout layout = new TableLayout(LAYOUT_COLS, LAYOUT_ROWS);
-				int vg = layout.getVGap();
+//				int vg = layout.getVGap();
 //				int w = 25 * rowHeight;
 //				// int h = 153+(rowHeight+0)*SectionEditor.numberOfSections;
 //				int h = (SectionEditor.numberOfSections) * rowHeight + 4 * auxHeight


### PR DESCRIPTION
- use preferred sizes for rows in section and tune editors to attempt to fix Linux bug
- Wrap in scroll panes since the windows got bigger as a result
- Add missing calls to pack() which was causing sizes to not get calculated properly
Not a long-term solution, but I want to see if this fixes the bug.