### PR TITLE
Add histogram coloring and horiz lines, bump to 3.1.9

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -45,6 +45,14 @@ Thanks to all who gave feedback of features, bugs plus suggestions.
 
 Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 ================
+
+Version 3.1.9
+- Tweaked histogram colors. Green is for polyphony count under 45 notes, yellow is 45 to 64, and red is 64+.
+- Added horizontal lines to histogram to show where the two color thresholds are.
+
+Version 3.1.8
+- Shrink abctools icon to mitigate antivirus false positive
+
 Version 3.1.7
 - Fixed exporting to ABC would change histogram
 - Fixed delays were accounted for twice when making histogram

--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -49,6 +49,7 @@ Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 Version 3.1.9
 - Tweaked histogram colors. Green is for polyphony count under 45 notes, yellow is 45 to 64, and red is 64+.
 - Added horizontal lines to histogram to show where the two color thresholds are.
+- Maestro won't complain about a missing midi/abc file if Maestro can find the file in the MSX directory.
 
 Version 3.1.8
 - Shrink abctools icon to mitigate antivirus false positive

--- a/src/com/digero/abcplayer/version.txt
+++ b/src/com/digero/abcplayer/version.txt
@@ -1,1 +1,1 @@
-version.AbcPlayer=3.1.7
+version.AbcPlayer=3.1.9

--- a/src/com/digero/common/view/ColorTable.java
+++ b/src/com/digero/common/view/ColorTable.java
@@ -68,8 +68,10 @@ public enum ColorTable
 	BAR_EDITED(new Color(0,32,0)),
 	BAR_LINE_EDITED(new Color(30,75,30)),
 	
-	NOTE_POLYPHONY       (new Color(150,190,20)),
-	NOTE_POLYPHONY_ON    (new Color(0xF2F2F2));
+	NOTE_POLYPHONY         (new Color(150,190,20)),
+	NOTE_POLYPHONY_ON      (new Color(0xF2F2F2)),
+	NOTE_POLYPHONY_WARNING (Color.getHSBColor(0.1f, 1.00f, 1.00f)),
+	NOTE_POLYPHONY_OVER    (Color.getHSBColor(0f, 1.00f, 1.00f));
 	//NOTE_PRUNED (new Color(1f,1f,0f));
 
 	private Color value;

--- a/src/com/digero/common/view/ColorTable.java
+++ b/src/com/digero/common/view/ColorTable.java
@@ -70,7 +70,7 @@ public enum ColorTable
 	
 	NOTE_POLYPHONY         (new Color(150,190,20)),
 	NOTE_POLYPHONY_ON      (new Color(0xF2F2F2)),
-	NOTE_POLYPHONY_WARNING (Color.getHSBColor(0.1f, 1.00f, 1.00f)),
+	NOTE_POLYPHONY_WARNING (new Color(0xFECE19)),
 	NOTE_POLYPHONY_OVER    (Color.getHSBColor(0f, 1.00f, 1.00f));
 	//NOTE_PRUNED (new Color(1f,1f,0f));
 

--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -322,6 +322,11 @@ public class AbcSong implements IDiscardable, AbcMetadataSource {
 
 	private void tryToLoadFromFile(FileResolver fileResolver, boolean isAbc, MiscSettings miscSettings) {
 		try {
+			File sourceInCurrentDir = new File(saveFile.getParentFile(), sourceFile.getName());
+			if (!sourceFile.exists() && sourceInCurrentDir.exists()) {
+				sourceFile = sourceInCurrentDir;
+			}
+			
 			if (isAbc) {
 				AbcInfo abcInfo = new AbcInfo();
 

--- a/src/com/digero/maestro/version.txt
+++ b/src/com/digero/maestro/version.txt
@@ -1,1 +1,1 @@
-version.Maestro=3.1.7
+version.Maestro=3.1.9

--- a/src/com/digero/maestro/view/HistogramPanel.java
+++ b/src/com/digero/maestro/view/HistogramPanel.java
@@ -101,7 +101,7 @@ public class HistogramPanel extends JPanel implements IDiscardable, TableLayoutC
 
 		currentCountLabel = new JLabel();
 		currentCountLabel.setForeground(ColorTable.PANEL_TEXT_DISABLED.get());
-		currentCountLabel.setToolTipText("Number of concurrent playing notes.\nThis is useful due to lotro limitation of 64 sounds.\nIncluded in those 64 is dance footsteps and emotes.");
+		currentCountLabel.setToolTipText("Number of concurrent playing notes.\nThis is useful due to lotro's limitation of 64 sounds, including dance footsteps and emotes.\nGreen sections have under 45 notes at once, and shouldn't have note loss.\nYellow sections have 45+ notes, and red sections have 64+ notes.");
 		updateCountLabel();
 
 		add(gutter, GUTTER_COLUMN + ", 0");

--- a/src/com/digero/maestro/view/HistogramPanel.java
+++ b/src/com/digero/maestro/view/HistogramPanel.java
@@ -3,6 +3,7 @@ package com.digero.maestro.view;
 import info.clearthought.layout.TableLayout;
 import info.clearthought.layout.TableLayoutConstants;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.util.ArrayList;
@@ -42,8 +43,9 @@ public class HistogramPanel extends JPanel implements IDiscardable, TableLayoutC
 	static final int COUNT_COLUMN = 2;
 	static final int GRAPH_COLUMN = 3;
 	
-	static final int CLIP_MAX_NOTES = 70;// Show from 0 to 70 notes
-	static final int ORANGE_NOTES   = 45;// Over or equal to 45 and they go orange color. The limit is 64, but emotes and dances also fill.
+	public static final int CLIP_MAX_NOTES = 80;// Show from 0 to 80 notes
+	public static final int ORANGE_NOTES   = 45;// Over or equal to 45 and they go orange color. The limit is 64, but emotes and dances also fill.
+	public static final int RED_NOTES      = 64;//Over or equal to 64, notes become red.
 	static final int EXTRA_COUNT_COLUMN_WIDTH = 50;
 	static final int HISTOGRAM_HEIGHT = 64;
 
@@ -170,7 +172,10 @@ public class HistogramPanel extends JPanel implements IDiscardable, TableLayoutC
 			super(sequencer, sequenceInfo, null, 0, CLIP_MAX_NOTES, 1, 2);
 			
 			setOctaveLinesVisible(false);
+			setHistogramThresholdLinesVisible(true);
 			setNoteColor(ColorTable.NOTE_POLYPHONY);
+			setBadNoteColor(ColorTable.NOTE_POLYPHONY_WARNING);
+			setExtraBadNoteColor(ColorTable.NOTE_POLYPHONY_OVER);
 			setNoteOnColor(ColorTable.NOTE_POLYPHONY_ON);
 			setNoteOnExtraHeightPix(0);
 			setNoteOnOutlineWidthPix(0);
@@ -208,6 +213,11 @@ public class HistogramPanel extends JPanel implements IDiscardable, TableLayoutC
 		@Override
 		protected boolean isNotePlayable(NoteEvent ne, int addition) {
 			return ne.note.id < ORANGE_NOTES;
+		}
+		
+		@Override
+		protected boolean isNoteExtraBad(NoteEvent ne, int addition) {
+			return ne.note.id >= RED_NOTES;
 		}
 		
 		@Override


### PR DESCRIPTION
- Add a color to the histogram for notes > 64, edit color of notes between 45 and 64
- Add horizontal bars at the 45 and 64 positions
- Auto-resolve missing midi/abc file if a source file with the same name exists in the msx file's directory
- Bump version to 3.1.9