### PR TITLE
Fix skipping character after parsing tuplets

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -54,6 +54,8 @@ Version 3.1.9
 - Adjustment for how histogram count very long notes that are being broken up.
 - Added option for Ignore expression messages. This is mostly useful for people that commonly use self made MIDIs output from Musescore,
     and want a 1:1 relationship between note velocities. If in doubt, leave it unchecked.
+- Fix ABC triplet parsing bug, which caused some ABC files to have parsing errors.
+- Add support for parsing ABC files with bar repeat symbols. Maestro/AbcPlayer will play repeating sections only once, just as Lotro does.
 
 Version 3.1.8
 - Shrink abctools icon to mitigate antivirus false positive

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -394,7 +394,7 @@ public class AbcToMidi {
 								boolean foundPipe = false;
 								for (int j = i + 1; j < parseEnd; j++) {
 									if (line.charAt(j) == '|') {
-										i = j; // Skip past :::::| (legal in lotro, so we should support it.. even though lotro doesn't support |:)
+										i = j; // Skip past :::::| (legal in lotro, so we should support it.. even though lotro doesn't support |::)
 										foundPipe = true;
 										if (trackNumber == 1)
 											abcInfo.addBar(Math.round(chordStartTick));

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -378,11 +378,35 @@ public class AbcToMidi {
 									abcInfo.addBar(Math.round(chordStartTick));
 
 								accidentals.clear();
-								if (i + 1 < line.length() && line.charAt(i + 1) == ']') {
-									i++; // Skip |]
+								if (i + 1 < line.length() && (line.charAt(i + 1) == ']' || line.charAt(i+1) == ':')) {
+									i++; // Skip |], |:
 								} else if (trackNumber == 1) {
 									abcInfo.addBar(Math.round(chordStartTick));
 								}
+								break;
+							
+							case ':': // Beginning of repeat end bar line :| ::| :::::::|
+								if (inChord) {
+									throw new ParseException("Unexpected '" + ch + "' inside a chord", fileName,
+											lineNumber, i);
+								}
+
+								boolean foundPipe = false;
+								for (int j = i + 1; j < parseEnd; j++) {
+									if (line.charAt(j) == '|') {
+										i = j; // Skip past :::::| (legal in lotro, so we should support it.. even though lotro doesn't support |:)
+										foundPipe = true;
+										if (trackNumber == 1)
+											abcInfo.addBar(Math.round(chordStartTick));
+										break;
+									}
+								}
+								
+								if (!foundPipe) {
+									throw new ParseException("Expected to see '|' after parsing '" + ch + "'", fileName,
+											lineNumber, i);
+								}
+								
 								break;
 
 							case '+': {

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -142,6 +142,10 @@ public class AbcToMidi {
 			for (String line : fileAndData.lines) {
 				lineNumberForRegions++;
 				lineNumber++;
+				
+				if (lineNumber == 90) {
+					System.out.println("at line 90");
+				}
 
 				// Handle extended info
 				Matcher xInfoMatcher = XINFO_PATTERN.matcher(line);
@@ -418,7 +422,7 @@ public class AbcToMidi {
 										for (int j = i + 1; j < line.length(); j++) {
 											if (line.charAt(j) != ':' && !Character.isDigit(line.charAt(j))) {
 												tuplet = new Tuplet(line.substring(i + 1, j), info.isCompoundMeter());
-												i = j;
+												i = j - 1;
 												break;
 											}
 										}

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -142,10 +142,6 @@ public class AbcToMidi {
 			for (String line : fileAndData.lines) {
 				lineNumberForRegions++;
 				lineNumber++;
-				
-				if (lineNumber == 90) {
-					System.out.println("at line 90");
-				}
 
 				// Handle extended info
 				Matcher xInfoMatcher = XINFO_PATTERN.matcher(line);


### PR DESCRIPTION
When parsing something like:

`| (3[A,e]cA`

this code is hit when we detect `(`, which parses the tuplet number:

```
for (int j = i + 1; j < line.length(); j++) {
	if (line.charAt(j) != ':' && !Character.isDigit(line.charAt(j))) {
		tuplet = new Tuplet(line.substring(i + 1, j), info.isCompoundMeter());
		i = j;
		break;
	}
}
```

After this loop, i = j = 4, pointing at the character [

But then the outer for loop increments i again before we parse the next character, so i = 5

So we skip parsing the [ character

Solution is to set `i = j - 1;`