### PR TITLE
ABC Player Tweaks

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -48,6 +48,7 @@ Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 
 Version 3.2.7
 - You can hold shift while clicking a solo/mute button to deselect all the other buttons of that type. Works in Maestro and AbcPlayer.
+- Flat light and dark themes are added for AbcPlayer, and the old default theme is removed.
 
 Version 3.2.6
 - Polyphony histogram now reacts to muting or soloing parts.

--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -46,6 +46,9 @@ Thanks to all who gave feedback of features, bugs plus suggestions.
 Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 ================
 
+Version 3.2.7
+- You can hold shift while clicking a solo/mute button to deselect all the other buttons of that type. Works in Maestro and AbcPlayer.
+
 Version 3.2.6
 - Polyphony histogram now reacts to muting or soloing parts.
 - Minimum and maximum note used can now be set in section editor.

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -65,7 +65,9 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
+import javax.swing.text.StyleContext;
 
+import com.digero.abcplayer.view.AbcPlayerSettingsDialog;
 import com.digero.abcplayer.view.HighlightAbcNotesFrame;
 import com.digero.abcplayer.view.TrackListPanel;
 import com.digero.abcplayer.view.TrackListPanelCallback;
@@ -92,6 +94,9 @@ import com.digero.common.view.NativeVolumeBar;
 import com.digero.common.view.SongPositionBar;
 import com.digero.common.view.SongPositionLabel;
 import com.digero.common.view.TempoBar;
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
 
 import info.clearthought.layout.TableLayout;
 import info.clearthought.layout.TableLayoutConstants;
@@ -131,7 +136,12 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		System.setProperty("sun.sound.useNewAudioEngine", "true");
 
 		try {
-			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+//			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+			UIManager.setLookAndFeel(new FlatMacLightLaf());
+			Font font = UIManager.getFont("defaultFont");
+			Font newFont = StyleContext.getDefaultStyleContext().getFont(font.getFamily(), font.getStyle(), 12);
+			UIManager.put("defaultFont", newFont);
+			FlatLaf.updateUI();
 		} catch (Exception e) {
 		}
 
@@ -747,7 +757,12 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		});
 
 		toolsMenu.addSeparator();
-
+		
+		JMenuItem otherOptions = toolsMenu.add(new JMenuItem("More Options..."));
+		otherOptions.addActionListener(e -> { doSettingsDialog(); });
+		
+		toolsMenu.addSeparator();
+		
 		JMenuItem about = toolsMenu.add(new JMenuItem("About " + APP_NAME + "..."));
 		about.setMnemonic(KeyEvent.VK_A);
 		about.addActionListener(
@@ -792,6 +807,11 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 			recentItems.add(newRecent);
 		}
 		recentPrefsWrite();
+	}
+	
+	private void doSettingsDialog() {
+		AbcPlayerSettingsDialog dialog = new AbcPlayerSettingsDialog(this, prefs);
+		dialog.setVisible(true);
 	}
 
 	private void recentRemove(final String fileNameToRemove) {

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -85,6 +85,7 @@ import com.digero.common.util.ExtensionFileFilter;
 import com.digero.common.util.FileFilterDropListener;
 import com.digero.common.util.LotroParseException;
 import com.digero.common.util.ParseException;
+import com.digero.common.util.Themer;
 import com.digero.common.util.Util;
 import com.digero.common.util.Version;
 import com.digero.common.view.AboutDialog;
@@ -137,11 +138,7 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 
 		try {
 //			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-			UIManager.setLookAndFeel(new FlatMacLightLaf());
-			Font font = UIManager.getFont("defaultFont");
-			Font newFont = StyleContext.getDefaultStyleContext().getFont(font.getFamily(), font.getStyle(), 12);
-			UIManager.put("defaultFont", newFont);
-			FlatLaf.updateUI();
+			Themer.setLookAndFeel(Preferences.userNodeForPackage(AbcPlayer.class).node("miscSettings"));
 		} catch (Exception e) {
 		}
 

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -6,6 +6,7 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Image;
+import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
@@ -62,10 +63,8 @@ import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
-import javax.swing.text.StyleContext;
 
 import com.digero.abcplayer.view.AbcPlayerSettingsDialog;
 import com.digero.abcplayer.view.HighlightAbcNotesFrame;
@@ -95,12 +94,10 @@ import com.digero.common.view.NativeVolumeBar;
 import com.digero.common.view.SongPositionBar;
 import com.digero.common.view.SongPositionLabel;
 import com.digero.common.view.TempoBar;
-import com.formdev.flatlaf.FlatLaf;
-import com.formdev.flatlaf.themes.FlatMacDarkLaf;
-import com.formdev.flatlaf.themes.FlatMacLightLaf;
 
 import info.clearthought.layout.TableLayout;
 import info.clearthought.layout.TableLayoutConstants;
+import net.miginfocom.swing.MigLayout;
 
 @SuppressWarnings("serial")
 public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConstants, TrackListPanelCallback {
@@ -137,8 +134,8 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		System.setProperty("sun.sound.useNewAudioEngine", "true");
 
 		try {
-//			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-			Themer.setLookAndFeel(Preferences.userNodeForPackage(AbcPlayer.class).node("miscSettings"));
+			Preferences prefs = Preferences.userNodeForPackage(AbcPlayer.class).node("miscSettings");
+			Themer.setLookAndFeel(prefs.get("theme", Themer.FLAT_LIGHT_THEME), prefs.getInt("fontSize", Themer.DEFAULT_FONT_SIZE));
 		} catch (Exception e) {
 		}
 
@@ -372,11 +369,13 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		trackListScroller.getVerticalScrollBar().setUnitIncrement(TrackListPanel.TRACKLIST_ROWHEIGHT);
 		trackListScroller.setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, Color.GRAY));
 
-		JPanel controlPanel = new JPanel(new TableLayout(//
-				new double[] { 4, SongPositionBar.SIDE_PAD, 0.5, 4, PREFERRED, 4, PREFERRED, 4, 0.5,
-						SongPositionBar.SIDE_PAD, 4, PREFERRED, 4 }, //
-				new double[] { 4, PREFERRED, 4, PREFERRED, 4 }));
-
+//		JPanel controlPanel = new JPanel(new TableLayout(//
+//				new double[] { 4, SongPositionBar.SIDE_PAD, 0.5, 4, PREFERRED, 4, PREFERRED, 4, 0.5,
+//						SongPositionBar.SIDE_PAD, 4, PREFERRED, 4 }, //
+//				new double[] { 4, PREFERRED, 4, PREFERRED, 4 }));
+		
+		JPanel controlPanel = new JPanel(new MigLayout("fillx, wrap 5", "[][grow -1][grow -1][][grow -1]"));
+		
 		songPositionBar = new SongPositionBar(sequencer);
 		songPositionLabel = new SongPositionLabel(sequencer);
 		barNumberLabel = new BarNumberLabel(sequencer, null);
@@ -388,15 +387,19 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		pauseIconDisabled = IconLoader.getDisabledIcon("pause.png");
 		stopIcon = IconLoader.getImageIcon("stop.png");
 		stopIconDisabled = IconLoader.getDisabledIcon("stop.png");
+		
+		final Insets playControlButtonMargin = new Insets(5, 20, 5, 20);
 
 		playButton = new JButton(playIcon);
 		playButton.setDisabledIcon(playIconDisabled);
 		playButton.setEnabled(false);
+		playButton.setMargin(playControlButtonMargin);
 		playButton.addActionListener(e -> playPause());
 
 		stopButton = new JButton(stopIcon);
 		stopButton.setDisabledIcon(stopIconDisabled);
 		stopButton.setEnabled(false);
+		stopButton.setMargin(playControlButtonMargin);
 		stopButton.addActionListener(e -> stop());
 
 		tempoBar = new TempoBar(sequencer);
@@ -414,13 +417,21 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		volumePanel.add(volumeLabel, BorderLayout.NORTH);
 		volumePanel.add(volumeBar, BorderLayout.CENTER);
 
-		controlPanel.add(songPositionBar, "1, 1, 9, 1");
-		controlPanel.add(songPositionLabel, "11, 1");
-		controlPanel.add(playButton, "4, 3");
-		controlPanel.add(stopButton, "6, 3");
-		controlPanel.add(tempoPanel, "2, 3, c, c");
-		controlPanel.add(volumePanel, "8, 3, c, c");
-		controlPanel.add(barNumberLabel, "9, 3, 11, 3, r, t");
+//		controlPanel.add(songPositionBar, "1, 1, 9, 1");
+//		controlPanel.add(songPositionLabel, "11, 1");
+//		controlPanel.add(playButton, "4, 3");
+//		controlPanel.add(stopButton, "6, 3");
+//		controlPanel.add(tempoPanel, "2, 3, c, c");
+//		controlPanel.add(volumePanel, "8, 3, c, c");
+//		controlPanel.add(barNumberLabel, "9, 3, 11, 3, r, t");
+		
+		controlPanel.add(songPositionBar, "spanx 4, growx");
+		controlPanel.add(songPositionLabel, "right");
+		controlPanel.add(tempoPanel, "center");
+		controlPanel.add(playButton, "right");
+		controlPanel.add(stopButton);
+		controlPanel.add(volumePanel, "center");
+		controlPanel.add(barNumberLabel, "right");
 
 		sequencer.addChangeListener(evt -> {
 			SequencerProperty p = evt.getProperty();
@@ -807,8 +818,9 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 	}
 	
 	private void doSettingsDialog() {
-		AbcPlayerSettingsDialog dialog = new AbcPlayerSettingsDialog(this, prefs);
+		AbcPlayerSettingsDialog dialog = new AbcPlayerSettingsDialog(this, prefs.node("miscSettings"));
 		dialog.setVisible(true);
+		dialog.dispose();
 	}
 
 	private void recentRemove(final String fileNameToRemove) {

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -483,7 +483,7 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 			return;
 
 		if (abcViewFrame == null) {
-			abcViewFrame = new HighlightAbcNotesFrame(sequencer);
+			abcViewFrame = new HighlightAbcNotesFrame(sequencer, prefs);
 			abcViewFrame.setTitle(getTitle());
 			abcViewFrame.setIconImages(getIconImages());
 			abcViewFrame.addDropListener(dropListener);

--- a/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
+++ b/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
@@ -19,28 +19,34 @@ import info.clearthought.layout.TableLayout;
 import info.clearthought.layout.TableLayoutConstants;
 
 public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConstants{
-
-	private boolean success = false;
 	
 	private JTabbedPane tabPanel;
 	
 	private static final int PAD = 4;
 	
+	private final JComboBox<String> themeBox = new JComboBox<>();
+	private final JComboBox<String> fontBox = new JComboBox<>();
+	
+	private final Preferences prefs;
+	
 	public AbcPlayerSettingsDialog(JFrame owner, Preferences abcPlayerPrefs) {
 		super(owner, "More Options", true);
+		
+		prefs = abcPlayerPrefs;
 		
 		JButton okButton = new JButton("OK");
 		getRootPane().setDefaultButton(okButton);
 		okButton.setMnemonic('O');
 		okButton.addActionListener(e -> {
-			success = true;
+			prefs.put("theme", (String)themeBox.getSelectedItem());
+			prefs.putInt("fontSize", Integer.parseInt((String) fontBox.getSelectedItem()));
+			System.out.println("test");
 			AbcPlayerSettingsDialog.this.setVisible(false);
 		});
 		
 		JButton cancelButton = new JButton("Cancel");
 		cancelButton.setMnemonic('C');
 		cancelButton.addActionListener(e -> {
-			success = false;
 			AbcPlayerSettingsDialog.this.setVisible(false);
 		});
 		
@@ -53,12 +59,13 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 		JPanel buttonsContainerPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, PAD / 2));
 		buttonsContainerPanel.add(buttonsPanel);
 		
-		tabPanel = new JTabbedPane();
-		tabPanel.addTab("More Options", createMoreOptionsPanel());
-		tabPanel.setFocusable(false);
+//		tabPanel = new JTabbedPane();
+//		tabPanel.addTab("More Options", createMoreOptionsPanel());
+//		tabPanel.setFocusable(false);
 		
 		JPanel mainPanel = new JPanel(new BorderLayout(PAD,PAD));
-		mainPanel.add(tabPanel, BorderLayout.CENTER);
+		mainPanel.setBorder(BorderFactory.createEmptyBorder(PAD, PAD, PAD, PAD));
+		mainPanel.add(createMoreOptionsPanel(), BorderLayout.CENTER);
 		mainPanel.add(buttonsContainerPanel, BorderLayout.SOUTH);
 		
 		setContentPane(mainPanel);
@@ -73,27 +80,25 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 	
 	private JPanel createMoreOptionsPanel() {
 		
-		final JLabel themeText = new JLabel("Theme (Requires restart):");
-		final JComboBox<String> themeBox = new JComboBox<>();
+		final JLabel themeLabel = new JLabel("Theme (Requires restart):");
 		
 		themeBox.setToolTipText(
 				"<html>Select the theme for Maestro. Must restart Maestro for it to take effect.</html>");
-		//themeBox.addItem(defaultStr);
 		for (String theme : Themer.themes) {
 			themeBox.addItem(theme);
 		}
 		themeBox.setEditable(false);
-		themeBox.addActionListener(e -> {
-		});
-//		themeBox.setSelectedItem();
+		themeBox.setSelectedItem(prefs.get("theme", Themer.FLAT_LIGHT_THEME));
 		
 		final JLabel fontSizeLabel = new JLabel("Font size (requires restart)");
-		final JComboBox<String> fontBox = new JComboBox<>();
 		
+		fontBox.setToolTipText(
+				"<html>Select a font size. Must restart Maestro for it to take effect.</html>");
 		fontBox.setEditable(false);
 		for (int i : Themer.fontSizes) {
 			fontBox.addItem(Integer.toString(i));
 		}
+		fontBox.setSelectedItem(Integer.toString(prefs.getInt("fontSize", Themer.DEFAULT_FONT_SIZE)));
 		
 		TableLayout layout = new TableLayout();
 		layout.insertColumn(0, FILL);
@@ -103,6 +108,12 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 		panel.setBorder(BorderFactory.createEmptyBorder(PAD, PAD, PAD, PAD));
 		
 		int row = -1;
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(themeLabel, "0, " + row);
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(themeBox, "0, " + row);
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(fontSizeLabel, "0, " + row);

--- a/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
+++ b/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.util.prefs.Preferences;
 
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
@@ -11,6 +12,8 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
+
+import com.digero.common.util.Themer;
 
 import info.clearthought.layout.TableLayout;
 import info.clearthought.layout.TableLayoutConstants;
@@ -69,10 +72,44 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 	}
 	
 	private JPanel createMoreOptionsPanel() {
+		
+		final JLabel themeText = new JLabel("Theme (Requires restart):");
+		final JComboBox<String> themeBox = new JComboBox<>();
+		
+		themeBox.setToolTipText(
+				"<html>Select the theme for Maestro. Must restart Maestro for it to take effect.</html>");
+		//themeBox.addItem(defaultStr);
+		for (String theme : Themer.themes) {
+			themeBox.addItem(theme);
+		}
+		themeBox.setEditable(false);
+		themeBox.addActionListener(e -> {
+		});
+//		themeBox.setSelectedItem();
+		
 		final JLabel fontSizeLabel = new JLabel("Font size (requires restart)");
 		final JComboBox<String> fontBox = new JComboBox<>();
 		
-//		fontBox.setToolTipText();
-		return new JPanel();
+		fontBox.setEditable(false);
+		for (int i : Themer.fontSizes) {
+			fontBox.addItem(Integer.toString(i));
+		}
+		
+		TableLayout layout = new TableLayout();
+		layout.insertColumn(0, FILL);
+		layout.setVGap(PAD);
+
+		JPanel panel = new JPanel(layout);
+		panel.setBorder(BorderFactory.createEmptyBorder(PAD, PAD, PAD, PAD));
+		
+		int row = -1;
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(fontSizeLabel, "0, " + row);
+		
+		layout.insertRow(++row, PREFERRED);
+		panel.add(fontBox, "0, " + row);
+		
+		return panel;
 	}
 }

--- a/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
+++ b/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
@@ -1,0 +1,78 @@
+package com.digero.abcplayer.view;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.util.prefs.Preferences;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+
+import info.clearthought.layout.TableLayout;
+import info.clearthought.layout.TableLayoutConstants;
+
+public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConstants{
+
+	private boolean success = false;
+	
+	private JTabbedPane tabPanel;
+	
+	private static final int PAD = 4;
+	
+	public AbcPlayerSettingsDialog(JFrame owner, Preferences abcPlayerPrefs) {
+		super(owner, "More Options", true);
+		
+		JButton okButton = new JButton("OK");
+		getRootPane().setDefaultButton(okButton);
+		okButton.setMnemonic('O');
+		okButton.addActionListener(e -> {
+			success = true;
+			AbcPlayerSettingsDialog.this.setVisible(false);
+		});
+		
+		JButton cancelButton = new JButton("Cancel");
+		cancelButton.setMnemonic('C');
+		cancelButton.addActionListener(e -> {
+			success = false;
+			AbcPlayerSettingsDialog.this.setVisible(false);
+		});
+		
+		JPanel buttonsPanel = new JPanel(new TableLayout(//
+				new double[] { 0.5, 0.5}, //
+				new double[] { PREFERRED }));
+		((TableLayout) buttonsPanel.getLayout()).setHGap(PAD);
+		buttonsPanel.add(okButton, "0, 0, f, f");
+		buttonsPanel.add(cancelButton, "1, 0, f, f");
+		JPanel buttonsContainerPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, PAD / 2));
+		buttonsContainerPanel.add(buttonsPanel);
+		
+		tabPanel = new JTabbedPane();
+		tabPanel.addTab("More Options", createMoreOptionsPanel());
+		tabPanel.setFocusable(false);
+		
+		JPanel mainPanel = new JPanel(new BorderLayout(PAD,PAD));
+		mainPanel.add(tabPanel, BorderLayout.CENTER);
+		mainPanel.add(buttonsContainerPanel, BorderLayout.SOUTH);
+		
+		setContentPane(mainPanel);
+		pack();
+		
+		if (owner != null) {
+			int left = owner.getX() + (owner.getWidth() - this.getWidth()) / 2;
+			int top = owner.getY() + (owner.getHeight() - this.getHeight()) / 2;
+			this.setLocation(left, top);
+		}
+	}
+	
+	private JPanel createMoreOptionsPanel() {
+		final JLabel fontSizeLabel = new JLabel("Font size (requires restart)");
+		final JComboBox<String> fontBox = new JComboBox<>();
+		
+//		fontBox.setToolTipText();
+		return new JPanel();
+	}
+}

--- a/src/com/digero/abcplayer/view/HighlightAbcNotesFrame.java
+++ b/src/com/digero/abcplayer/view/HighlightAbcNotesFrame.java
@@ -60,6 +60,7 @@ import com.digero.common.midi.Note;
 import com.digero.common.midi.SequencerEvent.SequencerProperty;
 import com.digero.common.midi.SequencerWrapper;
 import com.digero.common.util.NullCaret;
+import com.digero.common.util.Themer;
 import com.digero.common.util.Util;
 import com.digero.common.view.ColorTable;
 
@@ -98,7 +99,7 @@ public class HighlightAbcNotesFrame extends JFrame {
 	private JCheckBox autoScrollCheckBox;
 	private JComboBox<PartInfo> followTrackComboBox;
 
-	public HighlightAbcNotesFrame(SequencerWrapper seq) {
+	public HighlightAbcNotesFrame(SequencerWrapper seq, Preferences abcPlayerPreferences) {
 		super(AbcPlayer.APP_NAME);
 
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -139,7 +140,7 @@ public class HighlightAbcNotesFrame extends JFrame {
 
 		textArea = new JTextArea();
 		textArea.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-		textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
+		textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, abcPlayerPreferences.node("miscSettings").getInt("fontSize", Themer.DEFAULT_FONT_SIZE) + 2));
 		textArea.setEditable(false);
 		textArea.setLineWrap(false);
 		textArea.setHighlighter(highlighter);

--- a/src/com/digero/common/util/Themer.java
+++ b/src/com/digero/common/util/Themer.java
@@ -1,4 +1,4 @@
-package com.digero.maestro.view;
+package com.digero.common.util;
 
 import java.awt.Font;
 import java.util.prefs.Preferences;
@@ -8,14 +8,15 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.text.StyleContext;
 
 import com.digero.maestro.MaestroMain;
+import com.digero.maestro.view.MiscSettings;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 import com.formdev.flatlaf.themes.FlatMacLightLaf;
 
 public class Themer {
-	protected static final String[] themes = { "Flat Dark", "Flat Light", };
+	public static final String[] themes = { "Flat Dark", "Flat Light", };
 
-	protected static final int[] fontSizes = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24, 26, 28, 36 };
+	public static final int[] fontSizes = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24, 26, 28, 36 };
 
 	public static void setLookAndFeel() throws ClassNotFoundException, InstantiationException, IllegalAccessException,
 			UnsupportedLookAndFeelException {

--- a/src/com/digero/common/util/Themer.java
+++ b/src/com/digero/common/util/Themer.java
@@ -14,16 +14,20 @@ import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 import com.formdev.flatlaf.themes.FlatMacLightLaf;
 
 public class Themer {
-	public static final String[] themes = { "Flat Dark", "Flat Light", };
+	public static final String FLAT_LIGHT_THEME = "Flat Light";
+	public static final String FLAT_DARK_THEME = "Flat Dark";
+	
+	public static final String[] themes = { FLAT_DARK_THEME, FLAT_LIGHT_THEME, };
 
+	public static final int DEFAULT_FONT_SIZE = 12;
 	public static final int[] fontSizes = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24, 26, 28, 36 };
 
-	public static void setLookAndFeel(Preferences node) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+	public static void setLookAndFeel(String theme, int fontSize) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
 			UnsupportedLookAndFeelException {
-		MiscSettings settings = new MiscSettings(node,
-				true);
-		String theme = settings.theme;
-		int fontSize = settings.fontSize;
+//		MiscSettings settings = new MiscSettings(node,
+//				true);
+//		String theme = settings.theme;
+//		int fontSize = settings.fontSize;
 		boolean isOldTheme = false;
 		
 		if ("Default".equals(theme)) {

--- a/src/com/digero/common/util/Themer.java
+++ b/src/com/digero/common/util/Themer.java
@@ -18,9 +18,9 @@ public class Themer {
 
 	public static final int[] fontSizes = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24, 26, 28, 36 };
 
-	public static void setLookAndFeel() throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+	public static void setLookAndFeel(Preferences node) throws ClassNotFoundException, InstantiationException, IllegalAccessException,
 			UnsupportedLookAndFeelException {
-		MiscSettings settings = new MiscSettings(Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings"),
+		MiscSettings settings = new MiscSettings(node,
 				true);
 		String theme = settings.theme;
 		int fontSize = settings.fontSize;

--- a/src/com/digero/maestro/MaestroMain.java
+++ b/src/com/digero/maestro/MaestroMain.java
@@ -15,9 +15,10 @@ import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 
 import javax.swing.SwingUtilities;
+
+import com.digero.common.util.Themer;
 import com.digero.common.util.Version;
 import com.digero.maestro.view.ProjectFrame;
-import com.digero.maestro.view.Themer;
 
 //import org.boris.winrun4j.DDE;
 

--- a/src/com/digero/maestro/MaestroMain.java
+++ b/src/com/digero/maestro/MaestroMain.java
@@ -62,7 +62,7 @@ public class MaestroMain {
 		System.setProperty("sun.sound.useNewAudioEngine", "true");
 
 		try {
-			Themer.setLookAndFeel();
+			Themer.setLookAndFeel(Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings"));
 		} catch (Exception e) {
 			// Reset theme to default if an error occurred setting look and feel
 			Preferences preferences = Preferences.userNodeForPackage(MaestroMain.class);

--- a/src/com/digero/maestro/MaestroMain.java
+++ b/src/com/digero/maestro/MaestroMain.java
@@ -18,6 +18,7 @@ import javax.swing.SwingUtilities;
 
 import com.digero.common.util.Themer;
 import com.digero.common.util.Version;
+import com.digero.maestro.view.MiscSettings;
 import com.digero.maestro.view.ProjectFrame;
 
 //import org.boris.winrun4j.DDE;
@@ -62,7 +63,8 @@ public class MaestroMain {
 		System.setProperty("sun.sound.useNewAudioEngine", "true");
 
 		try {
-			Themer.setLookAndFeel(Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings"));
+			MiscSettings misc = new MiscSettings(Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings"), true);
+			Themer.setLookAndFeel(misc.theme, misc.fontSize);
 		} catch (Exception e) {
 			// Reset theme to default if an error occurred setting look and feel
 			Preferences preferences = Preferences.userNodeForPackage(MaestroMain.class);

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -943,7 +943,7 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants {
 		themeBox.setSelectedItem(miscSettings.theme);
 
 		fontBox.setToolTipText(
-				"<html>Select a font size. Only supported with a non-default theme. Must restart Maestro for it to take effect.</html>");
+				"<html>Select a font size. Must restart Maestro for it to take effect.</html>");
 		for (int i : Themer.fontSizes) {
 			fontBox.addItem(Integer.toString(i));
 		}

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -42,6 +42,7 @@ import com.digero.common.abc.LotroInstrument;
 import com.digero.common.abc.LotroInstrumentNick;
 import com.digero.common.midi.NoteFilterSequencerWrapper;
 import com.digero.common.util.ExtensionFileFilter;
+import com.digero.common.util.Themer;
 import com.digero.common.util.Util;
 import com.digero.common.view.LinkButton;
 import com.digero.maestro.MaestroMain;


### PR DESCRIPTION
- Add the same shift-click support for solo/mute buttons in AbcPlayer as my last PR for Maestro
- Remove the old theme and make flatlaf light the default instead
- Add a small "More Options" menu panel through the tools menu bar to access font/theme settings
- Rework the controls panel to use miglayout