### PR TITLE
Remove duplicate tempo factor scaling since sequence is already scale…

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -49,6 +49,7 @@ Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 Version 3.2.7
 - You can hold shift while clicking a solo/mute button to deselect all the other buttons of that type. Works in Maestro and AbcPlayer.
 - Flat light and dark themes are added for AbcPlayer, and the old default theme is removed.
+- Fixed a bug where Maestro would report incorrect song lengths for arrangements where the main tempo was changed.
 
 Version 3.2.6
 - Polyphony histogram now reacts to muting or soloing parts.

--- a/src/com/digero/common/view/SongPositionLabel.java
+++ b/src/com/digero/common/view/SongPositionLabel.java
@@ -60,18 +60,14 @@ public class SongPositionLabel extends JLabel implements Listener<SequencerEvent
 		long tickLength = Math.max(0, sequencer.getTickLength() - initialOffsetTick);
 		long tick = Math.max(0, Math.min(tickLength, sequencer.getThumbTick() - initialOffsetTick));
 
-		/*
-		 * if (adjustForTempo) { tick = Math.round(tick / sequencer.getTempoFactor()); tickLength =
-		 * Math.round(tickLength / sequencer.getTempoFactor()); }
-		 */
-
 		long micros = sequencer.tickToMicros(tick);
 		long length = sequencer.tickToMicros(tickLength);
 
-		if (adjustForTempo) {
-			micros = Math.round(micros / (double) sequencer.getTempoFactor());
-			length = Math.round(length / (double) sequencer.getTempoFactor());
-		}
+		// No longer needed after 3.0.2 - sequencer is already scaled by the tempo factor during refresh
+//		if (adjustForTempo) {
+//			micros = Math.round(micros / (double) sequencer.getTempoFactor());
+//			length = Math.round(length / (double) sequencer.getTempoFactor());
+//		}
 
 		if (micros != lastPrintedMicros || length != lastPrintedLength) {
 			lastPrintedMicros = micros;


### PR DESCRIPTION
Remove duplicate tempo factor scaling since sequence is already scaled after 3.0.2 to fix a bug where Maestro reports incorrect song positions and lengths

The bug that was introduced in a change I made in this PR: https://github.com/NikolaiVChr/maestro/commit/cdf5932206cb237b1ff13d6aad2528581b00dfc5

We switched to factoring in the scaled tempo in tempo events in Maestro, so the scaling applied to calculate the song duration and position for the label is applied on top of the already-scaled sequence length, so it isn't needed anymore.