### PR TITLE
Adapt zoom level to song length, fix bug where follow wouldn't snap a…

### DIFF
--- a/src/com/digero/maestro/view/NoteGraph.java
+++ b/src/com/digero/maestro/view/NoteGraph.java
@@ -127,6 +127,7 @@ public class NoteGraph extends JPanel implements Listener<SequencerEvent>, IDisc
 
 		setOpaque(true);
 		setPreferredSize(new Dimension(200, 16));
+		setMaximumSize(new Dimension(1000000, 2000));
 
 		addComponentListener(new ComponentAdapter() {
 			@Override


### PR DESCRIPTION
- Adapt zoom level to song length so that 10 seconds of song is on screen at max zoom level
- Fix bug where follow wouldn't snap at very beginning or end of song