### PR TITLE
Fix section editor and tune editor repositioning if off screen

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -46,6 +46,9 @@ Thanks to all who gave feedback of features, bugs plus suggestions.
 Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 ================
 
+Version 3.4.1
+- Section and tune editor windows are positioned better relative to the Maestro window, and will always appear fully on screen
+
 Version 3.4.0
 - Add a playlist feature to AbcPlayer
   - Access the playlist panel by pressing the new button next to the stop button

--- a/src/com/digero/maestro/view/SectionEditor.java
+++ b/src/com/digero/maestro/view/SectionEditor.java
@@ -377,6 +377,8 @@ public class SectionEditor {
 				}
 				
 				this.setVisible(true);
+				this.pack();
+				this.repaint();
 			}
 
 			private float processSections(TreeMap<Float, PartSection> tm, float lastEnd) {

--- a/src/com/digero/maestro/view/SectionEditor.java
+++ b/src/com/digero/maestro/view/SectionEditor.java
@@ -358,7 +358,6 @@ public class SectionEditor {
 					GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 					GraphicsDevice devices[] = ge.getScreenDevices();
 					Rectangle bounds = this.getBounds();
-					System.out.println("bx : " + bounds.x + " llx : " + lastLocation.x);
 					bounds.x = lastLocation.x;
 					bounds.y = lastLocation.y;
 					int areaOnScreen = 0;

--- a/src/com/digero/maestro/view/SectionEditor.java
+++ b/src/com/digero/maestro/view/SectionEditor.java
@@ -377,8 +377,6 @@ public class SectionEditor {
 				}
 				
 				this.setVisible(true);
-//				this.pack();
-				this.repaint();
 			}
 
 			private float processSections(TreeMap<Float, PartSection> tm, float lastEnd) {

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -2,7 +2,10 @@ package com.digero.maestro.view;
 
 import static javax.swing.SwingConstants.CENTER;
 
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -39,7 +42,7 @@ import info.clearthought.layout.TableLayoutConstants;
 
 public class TuneEditor {
 
-	private static Point lastLocation = new Point(100, 100);
+	private static Point lastLocation = null;
 	private static JDialog openDialog = null;
 	final static double[] LAYOUT_COLS_TABS = new double[] { 0.166, 0.166, 0.166, 0.166, 0.166, 0.17};
 	public static final int numberOfSectionsMax = 20;
@@ -308,17 +311,38 @@ public class TuneEditor {
 				this.getContentPane().add(scrollPane);
 				panel.revalidate();
 				this.pack();
-				Window window = SwingUtilities.windowForComponent(this);
-				if (window != null) {
-					// Lets keep the dialog inside the screen, in case the screen changed resolution
-					// since it was last popped up
-					int maxX = window.getBounds().width - this.getWidth();
-					int maxY = window.getBounds().height - this.getHeight();
-					int x = Math.max(0, Math.min(maxX, TuneEditor.lastLocation.x));
-					int y = Math.max(0, Math.min(maxY, TuneEditor.lastLocation.y));
-					this.setLocation(new Point(x, y));
+//				Window window = SwingUtilities.windowForComponent(this);
+//				if (window != null) {
+//					// Lets keep the dialog inside the screen, in case the screen changed resolution
+//					// since it was last popped up
+//					int maxX = window.getBounds().width - this.getWidth();
+//					int maxY = window.getBounds().height - this.getHeight();
+//					int x = Math.max(0, Math.min(maxX, TuneEditor.lastLocation.x));
+//					int y = Math.max(0, Math.min(maxY, TuneEditor.lastLocation.y));
+//					this.setLocation(new Point(x, y));
+//				} else {
+//					this.setLocation(TuneEditor.lastLocation);
+//				}
+				if (lastLocation == null) { // First launch of section editor, center it on maestro window
+					this.setLocationRelativeTo(jf);
 				} else {
-					this.setLocation(TuneEditor.lastLocation);
+					// Ensure that window is on screen fully if monitors or resolution changed
+					GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+					GraphicsDevice devices[] = ge.getScreenDevices();
+					Rectangle bounds = this.getBounds();
+					int areaOnScreen = 0;
+					for (GraphicsDevice d : devices) {
+						Rectangle screenBounds = d.getDefaultConfiguration().getBounds();
+						if (bounds.intersects(screenBounds)) {
+							Rectangle inter = bounds.intersection(screenBounds);
+							areaOnScreen += inter.width * inter.height;
+						}
+					}
+					if (areaOnScreen == bounds.width * bounds.height) {
+						this.setLocation(lastLocation);
+					} else {
+						this.setLocationRelativeTo(jf);
+					}
 				}
 				this.setVisible(true);
 				this.pack();

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -311,18 +311,6 @@ public class TuneEditor {
 				this.getContentPane().add(scrollPane);
 				panel.revalidate();
 				this.pack();
-//				Window window = SwingUtilities.windowForComponent(this);
-//				if (window != null) {
-//					// Lets keep the dialog inside the screen, in case the screen changed resolution
-//					// since it was last popped up
-//					int maxX = window.getBounds().width - this.getWidth();
-//					int maxY = window.getBounds().height - this.getHeight();
-//					int x = Math.max(0, Math.min(maxX, TuneEditor.lastLocation.x));
-//					int y = Math.max(0, Math.min(maxY, TuneEditor.lastLocation.y));
-//					this.setLocation(new Point(x, y));
-//				} else {
-//					this.setLocation(TuneEditor.lastLocation);
-//				}
 				if (lastLocation == null) { // First launch of section editor, center it on maestro window
 					this.setLocationRelativeTo(jf);
 				} else {
@@ -330,6 +318,8 @@ public class TuneEditor {
 					GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 					GraphicsDevice devices[] = ge.getScreenDevices();
 					Rectangle bounds = this.getBounds();
+					bounds.x = lastLocation.x;
+					bounds.y = lastLocation.y;
 					int areaOnScreen = 0;
 					for (GraphicsDevice d : devices) {
 						Rectangle screenBounds = d.getDefaultConfiguration().getBounds();
@@ -345,10 +335,9 @@ public class TuneEditor {
 					}
 				}
 				this.setVisible(true);
-				this.pack();
-				this.repaint();
+//				this.pack();
+//				this.repaint();
 				// this.setResizable(true);
-				// System.err.println(Thread.currentThread().getName()); Swing event thread
 			}
 			
 			private void addTuneLine(JButton add1) {

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -311,7 +311,7 @@ public class TuneEditor {
 				this.getContentPane().add(scrollPane);
 				panel.revalidate();
 				this.pack();
-				if (lastLocation == null) { // First launch of section editor, center it on maestro window
+				if (lastLocation == null) { // First launch of tune editor, center it on maestro window
 					this.setLocationRelativeTo(jf);
 				} else {
 					// Ensure that window is on screen fully if monitors or resolution changed

--- a/src/com/digero/maestro/view/TuneEditor.java
+++ b/src/com/digero/maestro/view/TuneEditor.java
@@ -335,8 +335,8 @@ public class TuneEditor {
 					}
 				}
 				this.setVisible(true);
-//				this.pack();
-//				this.repaint();
+				this.pack();
+				this.repaint();
 				// this.setResizable(true);
 			}
 			


### PR DESCRIPTION
On Linux with my dual monitor (one horiz and one vert) set up, the section and tune editors would appear off screen above my main monitor.
- Changed it so that on the first open of the editors, they appear centered relative to the main Maestro jframe
- For subsequent opens, they keep their previous position, but first check if the editor window at the prev position is still fully visible across all screens
- If not, they will spawn centered relative to the Maestro window again