### PR TITLE
Don't crash AbcPlayer if a pinned directory doesn't exist

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -47,6 +47,7 @@ Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 ================
 
 Version 3.4.1
+- Fix a bug where AbcPlayer would crash if a directory pinned to the ABC browser does not exist
 - Section and tune editor windows are positioned better relative to the Maestro window, and will always appear fully on screen
 
 Version 3.4.0

--- a/src/com/digero/common/util/AbcFileTreeModel.java
+++ b/src/com/digero/common/util/AbcFileTreeModel.java
@@ -91,11 +91,17 @@ public class AbcFileTreeModel implements TreeModel {
 		
 		 public void refresh() {
 			children = new ArrayList<AbcSongFileNode>();
-			if (!theFile.isDirectory()) {
+			if (!theFile.isDirectory() || !theFile.exists()) {
 				return;
 			}
 			
-			for (File file : theFile.listFiles(abcFilter)) {
+			File[] files = theFile.listFiles(abcFilter);
+			
+			if (files == null) {
+				return;
+			}
+			
+			for (File file : files) {
 				AbcSongFileNode node = new AbcSongFileNode(file);
 				node.refresh();
 				children.add(node);


### PR DESCRIPTION
- If a pinned directory in AbcPlayer's browser doesn't exist, we won't attempt to list it. It'll show up in the browser still but be empty.