### PR TITLE
Playlist improvements 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
 			<artifactId>commons-math3</artifactId>
 			<version>3.6.1</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-csv -->
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-csv</artifactId>
+		    <version>1.13.0</version>
+		</dependency>
 		<dependency>
 			<groupId>com.formdev</groupId>
 			<artifactId>flatlaf</artifactId>

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -1,5 +1,6 @@
 package com.digero.abcplayer;
 
+import java.awt.AWTKeyStroke;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
@@ -8,6 +9,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Image;
 import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
@@ -15,6 +17,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DropTarget;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -34,11 +37,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.prefs.Preferences;
 
@@ -51,6 +56,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -252,6 +258,8 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 	private AbcInfo abcInfo = new AbcInfo();
 
 	private Preferences prefs = Preferences.userNodeForPackage(AbcPlayer.class);
+	
+	private boolean playedFromFiletree = false;
 
 //	private boolean isExporting = false;
 
@@ -505,6 +513,7 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 				case PLAY_FROM_FILE:
 					playlistViewPanel.resetPlaylistPosition();
 					File f = (File)(e.getSource());
+					playedFromFiletree = true;
 					SwingUtilities.invokeLater(new OpenSongRunnable(false, f));
 					if (e.getShowSongView()) {
 						showPlaylistView = false;
@@ -513,6 +522,12 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 					break;
 				case CLOSE_SONG:
 					closeSong();
+					break;
+				case PLAYLIST_OPENED:
+					if (abcData == null || !sequencer.isRunning()) {
+						showPlaylistView = true;
+						updatePlaylistCardView();
+					}
 					break;
 				default: break;
 				}
@@ -535,6 +550,16 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 
 		setMinimumSize(new Dimension(320, 168));
 		Util.initWinBounds(this, prefs.node("window"), 450, 282);
+		
+		Set<AWTKeyStroke> emptyKeys = new HashSet<>();
+		setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, emptyKeys);
+		setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, emptyKeys);
+		
+		ActionListener tabListener = e -> {
+			showPlaylistView = !showPlaylistView;
+			updatePlaylistCardView();
+		};
+		this.getRootPane().registerKeyboardAction(tabListener, KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
 	}
 	
 	private void updatePlaylistCardView() {
@@ -988,11 +1013,11 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 
 	private void recentActionPerformed(ActionEvent evt, String title) {
 		File[] files = { new File(title) };
+		playlistViewPanel.resetPlaylistPosition();
 		if (!openSong(files)) {
 			// The file could not be opened, removing it from the recent list.
 			recentRemove(title);
 		}
-		playlistViewPanel.resetPlaylistPosition();
 	}
 
 	private boolean getAbcDataFromClipboard(ArrayList<String> data, boolean checkContents) {
@@ -1099,8 +1124,8 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 		if (result == JFileChooser.APPROVE_OPTION) {
 			prefs.put("openFileDialog.currentDirectory", openFileDialog.getCurrentDirectory().getAbsolutePath());
 
-			openSong(openFileDialog.getSelectedFiles());
 			playlistViewPanel.resetPlaylistPosition();
+			openSong(openFileDialog.getSelectedFiles());
 		}
 	}
 
@@ -1258,6 +1283,8 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 				}
 			}
 		}
+		
+		boolean wasPlaying = sequencer.isRunning();
 
 		sequencer.stop(); // pause
 		updateButtonStates();
@@ -1325,6 +1352,12 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 			String fileName = fileAndData.file.getAbsolutePath();
 			recentAdd(fileName);
 		}
+		
+		if (!wasPlaying && showPlaylistView && !playlistViewPanel.isPlayingFromPlaylist() && !playedFromFiletree) {
+			showPlaylistView = false;
+			updatePlaylistCardView();
+		}
+		playedFromFiletree = false;
 
 		return true;
 	}

--- a/src/com/digero/abcplayer/SetFilenameTemplate.java
+++ b/src/com/digero/abcplayer/SetFilenameTemplate.java
@@ -1,0 +1,230 @@
+package com.digero.abcplayer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.ListIterator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.digero.common.util.Pair;
+import com.digero.common.util.Util;
+import com.digero.maestro.abc.AbcMetadataSource;
+import com.digero.maestro.abc.ExportFilenameTemplate.Variable;
+import com.digero.maestro.view.SettingsDialog.MockMetadataSource;
+
+
+public class SetFilenameTemplate {
+	public static final String[] spaceReplaceChars = { " ", "", "_", "-" };
+	public static final String[] spaceReplaceLabels = { "Don't Replace", "Remove Spaces", "_ (Underscore)",
+			"- (Dash)" };
+
+	public static class Settings {
+		private String exportFilenamePattern;
+		private String whitespaceReplaceText;
+		private boolean partCountZeroPadded;
+
+		private final Preferences prefs;
+
+		private Settings(Preferences prefs) {
+			this.prefs = prefs;
+			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount - $SongTitle");
+			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
+			partCountZeroPadded = prefs.getBoolean("partCountZeroPadded", true);
+		}
+
+		public Settings(Settings source) {
+			this.prefs = source.prefs;
+			copyFrom(source);
+		}
+
+		private void save() {
+			prefs.put("exportFilenamePattern", exportFilenamePattern);
+			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
+			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
+		}
+
+		private void copyFrom(Settings source) {
+			this.exportFilenamePattern = source.exportFilenamePattern;
+			this.whitespaceReplaceText = source.whitespaceReplaceText;
+			this.partCountZeroPadded = source.partCountZeroPadded;
+		}
+
+		public String getExportFilenamePattern() {
+			return exportFilenamePattern;
+		}
+
+		public void setExportFilenamePattern(String exportFilenamePattern) {
+			this.exportFilenamePattern = exportFilenamePattern;
+		}
+
+		public String getWhitespaceReplaceText() {
+			return whitespaceReplaceText;
+		}
+
+		public void setWhitespaceReplaceText(String whitespaceReplaceText) {
+			this.whitespaceReplaceText = whitespaceReplaceText;
+		}
+
+		public boolean isPartCountZeroPadded() {
+			return partCountZeroPadded;
+		}
+
+		public void setPartCountZeroPadded(boolean zeroPadded) {
+			partCountZeroPadded = zeroPadded;
+		}
+
+		public void restoreDefaults() {
+			try {
+				prefs.clear();
+			} catch (BackingStoreException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+			Settings fresh = new Settings(prefs);
+			this.copyFrom(fresh);
+		}
+	}
+	
+	public abstract static class Variable {
+		private String description;
+		
+		private Variable(String description) {
+			this.description = description;
+		}
+
+		public abstract String getValue();
+
+		public String getDescription() {
+			return description;
+		}
+
+		@Override
+		public String toString() {
+			return getValue();
+		}
+	}
+	
+	private AbcMetadataSource metadata = new MockMetadataSource(null);
+	private String filename = "my abc file.abc";
+	private int index = 3;
+	private SortedMap<String, Variable> variables;
+	private Preferences prefsNode;
+	private Settings settings;
+	
+	public SetFilenameTemplate(Preferences prefs) {
+		this.prefsNode = prefs;
+		this.settings = new Settings(prefsNode);
+		
+		Comparator<String> caseInsensitiveStringComparator = String::compareToIgnoreCase;
+		
+		variables = new TreeMap<>(caseInsensitiveStringComparator);
+		
+		variables.put("$FileName", new Variable("The song's original filename") {
+			@Override
+			public String getValue() {
+				return filename;
+			}
+		});
+		
+		variables.put("$SongNumber", new Variable("The number position of the song in the setlist") {
+			@Override
+			public String getValue() {
+				return String.format("%03d", index + 1);
+			}
+		});
+		
+		variables.put("$PartCount", new Variable("Number of parts in the ABC file") {
+			@Override
+			public String getValue() {
+				return String.format("%02d",
+						getMetadataSource().getActivePartCount());
+			}
+		});
+		
+		variables.put("$SongComposer", new Variable("The song composer/artist, as entered in the \"C:\" field") {
+			@Override
+			public String getValue() {
+				return getMetadataSource().getComposer().trim();
+			}
+		});
+		
+		variables.put("$SongTranscriber", new Variable("The abc transcriber, as entered in the \"Z:\" field") {
+			@Override
+			public String getValue() {
+				return getMetadataSource().getTranscriber().trim();
+			}
+		});
+		
+		variables.put("$SongLength", new Variable("The playing time of the song in mm_ss format") {
+			@Override
+			public String getValue() {
+				return Util.formatDuration(getMetadataSource().getSongLengthMicros(), 0, '-');
+			}
+		});
+		
+		variables.put("$SongTitle", new Variable("The title of the song, as entered in the \"T:\" field") {
+			@Override
+			public String getValue() {
+				return getMetadataSource().getSongTitle().trim();
+			}
+		});
+	}
+	
+	public void setMetadataSource(AbcMetadataSource metadata) {
+		this.metadata = metadata;
+	}
+	
+	public void setIndex(int index) {
+		this.index = index;
+	}
+	
+	public void setFilename(String filename) {
+		this.filename = filename;
+	}
+	
+	public AbcMetadataSource getMetadataSource() {
+		return metadata;
+	}
+	
+	public String formatName() {
+		return formatName(settings);
+	}
+	
+	public String formatName(Settings settings) {
+		String name = settings.getExportFilenamePattern();
+
+		// Find all variables starting with $
+		Pattern regex = Pattern.compile("\\$[A-Za-z]+");
+		Matcher matcher = regex.matcher(name);
+
+		ArrayList<Pair<Integer, Integer>> matches = new ArrayList<>();
+		while (matcher.find()) {
+			matches.add(new Pair<>(matcher.start(), matcher.end()));
+		}
+
+		ListIterator<Pair<Integer, Integer>> reverseIter = matches.listIterator(matches.size());
+		while (reverseIter.hasPrevious()) {
+			Pair<Integer, Integer> match = reverseIter.previous();
+			Variable var = variables.get(name.substring(match.first, match.second));
+			if (var != null) {
+				String value = var.getValue();
+				value = value.replaceAll("\\s+", settings.getWhitespaceReplaceText());
+				name = name.substring(0, match.first) + value + name.substring(match.second);
+			}
+		}
+
+		name += ".abc";
+
+		return name;
+	}
+	
+	public SortedMap<String, Variable> getVariables() {
+		return Collections.unmodifiableSortedMap(variables);
+	}
+}

--- a/src/com/digero/abcplayer/SetFilenameTemplate.java
+++ b/src/com/digero/abcplayer/SetFilenameTemplate.java
@@ -6,90 +6,14 @@ import java.util.Comparator;
 import java.util.ListIterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.prefs.BackingStoreException;
-import java.util.prefs.Preferences;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.digero.abcplayer.view.PlaylistSetExportWizard.SetExportSettings;
+import com.digero.common.abctomidi.AbcInfo;
 import com.digero.common.util.Pair;
-import com.digero.common.util.Util;
-import com.digero.maestro.abc.AbcMetadataSource;
-import com.digero.maestro.abc.ExportFilenameTemplate.Variable;
-import com.digero.maestro.view.SettingsDialog.MockMetadataSource;
-
 
 public class SetFilenameTemplate {
-	public static final String[] spaceReplaceChars = { " ", "", "_", "-" };
-	public static final String[] spaceReplaceLabels = { "Don't Replace", "Remove Spaces", "_ (Underscore)",
-			"- (Dash)" };
-
-	public static class Settings {
-		private String exportFilenamePattern;
-		private String whitespaceReplaceText;
-		private boolean partCountZeroPadded;
-
-		private final Preferences prefs;
-
-		private Settings(Preferences prefs) {
-			this.prefs = prefs;
-			exportFilenamePattern = prefs.get("exportFilenamePattern", "$PartCount - $SongTitle");
-			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
-			partCountZeroPadded = prefs.getBoolean("partCountZeroPadded", true);
-		}
-
-		public Settings(Settings source) {
-			this.prefs = source.prefs;
-			copyFrom(source);
-		}
-
-		private void save() {
-			prefs.put("exportFilenamePattern", exportFilenamePattern);
-			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
-			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
-		}
-
-		private void copyFrom(Settings source) {
-			this.exportFilenamePattern = source.exportFilenamePattern;
-			this.whitespaceReplaceText = source.whitespaceReplaceText;
-			this.partCountZeroPadded = source.partCountZeroPadded;
-		}
-
-		public String getExportFilenamePattern() {
-			return exportFilenamePattern;
-		}
-
-		public void setExportFilenamePattern(String exportFilenamePattern) {
-			this.exportFilenamePattern = exportFilenamePattern;
-		}
-
-		public String getWhitespaceReplaceText() {
-			return whitespaceReplaceText;
-		}
-
-		public void setWhitespaceReplaceText(String whitespaceReplaceText) {
-			this.whitespaceReplaceText = whitespaceReplaceText;
-		}
-
-		public boolean isPartCountZeroPadded() {
-			return partCountZeroPadded;
-		}
-
-		public void setPartCountZeroPadded(boolean zeroPadded) {
-			partCountZeroPadded = zeroPadded;
-		}
-
-		public void restoreDefaults() {
-			try {
-				prefs.clear();
-			} catch (BackingStoreException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-
-			Settings fresh = new Settings(prefs);
-			this.copyFrom(fresh);
-		}
-	}
 	
 	public abstract static class Variable {
 		private String description;
@@ -110,16 +34,14 @@ public class SetFilenameTemplate {
 		}
 	}
 	
-	private AbcMetadataSource metadata = new MockMetadataSource(null);
+	private AbcInfo info = AbcInfo.getDummyAbcInfo();
 	private String filename = "my abc file.abc";
 	private int index = 3;
 	private SortedMap<String, Variable> variables;
-	private Preferences prefsNode;
-	private Settings settings;
+	private SetExportSettings settings;
 	
-	public SetFilenameTemplate(Preferences prefs) {
-		this.prefsNode = prefs;
-		this.settings = new Settings(prefsNode);
+	public SetFilenameTemplate(SetExportSettings settings) {
+		this.settings = settings;
 		
 		Comparator<String> caseInsensitiveStringComparator = String::compareToIgnoreCase;
 		
@@ -128,11 +50,11 @@ public class SetFilenameTemplate {
 		variables.put("$FileName", new Variable("The song's original filename") {
 			@Override
 			public String getValue() {
-				return filename;
+				return filename.endsWith(".abc") ? filename.substring(0, filename.lastIndexOf('.')) : filename;
 			}
 		});
 		
-		variables.put("$SongNumber", new Variable("The number position of the song in the setlist") {
+		variables.put("$SongIndex", new Variable("The number position of the song in the setlist") {
 			@Override
 			public String getValue() {
 				return String.format("%03d", index + 1);
@@ -142,42 +64,41 @@ public class SetFilenameTemplate {
 		variables.put("$PartCount", new Variable("Number of parts in the ABC file") {
 			@Override
 			public String getValue() {
-				return String.format("%02d",
-						getMetadataSource().getActivePartCount());
+				return String.format("%02d", info.getPartCount());
 			}
 		});
 		
 		variables.put("$SongComposer", new Variable("The song composer/artist, as entered in the \"C:\" field") {
 			@Override
 			public String getValue() {
-				return getMetadataSource().getComposer().trim();
+				return info.getComposer();
 			}
 		});
 		
 		variables.put("$SongTranscriber", new Variable("The abc transcriber, as entered in the \"Z:\" field") {
 			@Override
 			public String getValue() {
-				return getMetadataSource().getTranscriber().trim();
+				return info.getTranscriber();
 			}
 		});
 		
 		variables.put("$SongLength", new Variable("The playing time of the song in mm_ss format") {
 			@Override
 			public String getValue() {
-				return Util.formatDuration(getMetadataSource().getSongLengthMicros(), 0, '-');
+				return info.getSongDurationStr().replace(":", "-");
 			}
 		});
 		
 		variables.put("$SongTitle", new Variable("The title of the song, as entered in the \"T:\" field") {
 			@Override
 			public String getValue() {
-				return getMetadataSource().getSongTitle().trim();
+				return info.getTitle();
 			}
 		});
 	}
 	
-	public void setMetadataSource(AbcMetadataSource metadata) {
-		this.metadata = metadata;
+	public void setAbcInfo(AbcInfo info) {
+		this.info = info;
 	}
 	
 	public void setIndex(int index) {
@@ -188,15 +109,15 @@ public class SetFilenameTemplate {
 		this.filename = filename;
 	}
 	
-	public AbcMetadataSource getMetadataSource() {
-		return metadata;
+	public AbcInfo getAbcInfo() {
+		return info;
 	}
 	
 	public String formatName() {
 		return formatName(settings);
 	}
 	
-	public String formatName(Settings settings) {
+	public String formatName(SetExportSettings settings) {
 		String name = settings.getExportFilenamePattern();
 
 		// Find all variables starting with $

--- a/src/com/digero/abcplayer/view/AbcInfoTableModel.java
+++ b/src/com/digero/abcplayer/view/AbcInfoTableModel.java
@@ -2,6 +2,7 @@ package com.digero.abcplayer.view;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.table.AbstractTableModel;

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
+import java.awt.KeyboardFocusManager;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EventObject;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +48,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JTree;
+import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
@@ -95,7 +98,7 @@ public class AbcPlaylistPanel extends JPanel {
 		private boolean showSongView = false;
 		
 		public enum PlaylistEventType {
-			PLAY_FROM_ABCINFO, PLAY_FROM_FILE, CLOSE_SONG
+			PLAY_FROM_ABCINFO, PLAY_FROM_FILE, CLOSE_SONG, PLAYLIST_OPENED
 		}
 		
 		private final PlaylistEventType type;
@@ -222,6 +225,8 @@ public class AbcPlaylistPanel extends JPanel {
 		abcFileTree.collapseRow(0);
 		abcFileTree.setDragEnabled(true);
 		abcFileTree.setToggleClickCount(0);
+		abcFileTree.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet());
+		abcFileTree.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.emptySet());
 		abcFileTree.setTransferHandler(new TransferHandler() {
 			private static final long serialVersionUID = -3378747637795103415L;
 
@@ -370,6 +375,7 @@ public class AbcPlaylistPanel extends JPanel {
 		});
 		ToolTipManager.sharedInstance().registerComponent(abcFileTree);
 		fileTreeScrollPane = new JScrollPane(abcFileTree, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		fileTreeScrollPane.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), "none");
 		
 		JLabel abcBrowserLabel = new JLabel("ABC Browser");
 		abcBrowserLabel.setToolTipText("<html>Browser for your ABC files.<br>Double-click a song to play it, or drag selected songs to the playlist panel.</html>");
@@ -459,6 +465,11 @@ public class AbcPlaylistPanel extends JPanel {
 		playlistTable.setFillsViewportHeight(true);
 		playlistTable.setDragEnabled(true);
 		playlistTable.setDropMode(DropMode.INSERT_ROWS);
+		playlistTable.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), "none");
+		playlistTable.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), "none");
+		playlistTable.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), "none");
+		playlistTable.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet());
+		playlistTable.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.emptySet());
 		playlistTable.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent e) {
@@ -1027,6 +1038,10 @@ public class AbcPlaylistPanel extends JPanel {
 		updatePlaylistLabel();
 	}
 	
+	public boolean isPlayingFromPlaylist() {
+		return nowPlayingInfo != null;
+	}
+	
 	public void promptOpenPlaylist() {
 		if (openPlaylistChooser == null) {
 			openPlaylistChooser = new JFileChooser();
@@ -1052,6 +1067,8 @@ public class AbcPlaylistPanel extends JPanel {
 		
 		loadPlaylist(file);
 		playlistPrefs.put("playlistDirectory", openPlaylistChooser.getCurrentDirectory().getAbsolutePath());
+		
+		firePlaylistEvent(this, PlaylistEventType.PLAYLIST_OPENED);
 	}
 	
 	public boolean promptSavePlaylist() {

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -4,7 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
@@ -71,6 +70,7 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.tree.TreePath;
 
 import com.digero.abcplayer.AbcPlaylistXmlCoder;
+import com.digero.abcplayer.SetFilenameTemplate;
 import com.digero.abcplayer.view.AbcPlaylistPanel.PlaylistEvent.PlaylistEventType;
 import com.digero.common.abctomidi.AbcInfo;
 import com.digero.common.abctomidi.AbcToMidi;
@@ -156,6 +156,7 @@ public class AbcPlaylistPanel extends JPanel {
 	private JMenuItem saveMenuItem;
 	private JCheckBoxMenuItem autoplayMenuItem;
 	private JCheckBoxMenuItem playbackDelayMenuItem;
+	private JMenuItem exportSetMenuItem;
 	
 	private JFileChooser openPlaylistChooser = null;
 	private JFileChooser savePlaylistChooser = null;
@@ -279,23 +280,26 @@ public class AbcPlaylistPanel extends JPanel {
 		});
 		abcFileTree.addTreeSelectionListener(e -> {
 			// Only allow adding files if all the selected ones are abc files (no folders)
-			boolean noFoldersSelected = true;
+			boolean validSelection = true;
 			TreePath[] paths = abcFileTree.getSelectionPaths();
 			if (paths != null) {
 				for (TreePath path : paths) {
 					AbcSongFileNode f = (AbcSongFileNode)path.getLastPathComponent();
 					if (f.getFile().isDirectory()) {
-						noFoldersSelected = false;
+						validSelection = false;
 						break;
 					}
 				}
+			} else {
+				validSelection = false; // Nothing selected
 			}
-			addToPlaylistButton.setEnabled(noFoldersSelected);
+			addToPlaylistButton.setEnabled(validSelection);
 		});
 		abcFileTree.addTreeExpansionListener(new TreeExpansionListener() {
 			@Override
 			public void treeCollapsed(TreeExpansionEvent e) {
 				expandedAbcTrees.remove(e.getPath());
+				expandedAbcTrees.removeIf(path -> e.getPath().isDescendant(path));
 			}
 
 			@Override
@@ -601,6 +605,9 @@ public class AbcPlaylistPanel extends JPanel {
 		addToPlaylistButton.setEnabled(false);
 		addToPlaylistButton.addActionListener(e -> {
 //			addTreePathsToPlaylist(abcFileTree.getSelectionPaths());
+			if (abcFileTree.getSelectionPaths() == null) {
+				return;
+			}
 			addFilesToPlaylist(treePathsToFileList(abcFileTree.getSelectionPaths()), -1);
 		});
 		
@@ -742,6 +749,12 @@ public class AbcPlaylistPanel extends JPanel {
 				}
 			}
 		});
+		exportSetMenuItem = playlistMenu.add(new JMenuItem("Export Playlist as Set..."));
+		exportSetMenuItem.addActionListener(e -> {
+			SetFilenameTemplate template = new SetFilenameTemplate(prefs.node("setExportFilename"));
+			PlaylistSetExportWizard wiz = new PlaylistSetExportWizard((JFrame)SwingUtilities.getWindowAncestor(this), template);
+			wiz.setVisible(true);
+		});
 		playlistMenu.addSeparator();
 		autoplayMenuItem = (JCheckBoxMenuItem) playlistMenu.add(new JCheckBoxMenuItem("Enable Autoplay"));
 		autoplayMenuItem.setSelected(playlistPrefs.getBoolean("autoplay", true));
@@ -784,28 +797,27 @@ public class AbcPlaylistPanel extends JPanel {
 				topLevelDirs = dirs.stream().map(File::new).collect(Collectors.toList());
 				abcFileTreeModel.setDirectories(topLevelDirs);
 				abcFileTreeModel.refresh(sortType);
+				reExpandPaths();
 			}
 		});
 		JMenuItem refreshMenuItem = playlistMenu.add(new JMenuItem("Refresh Browser"));
 		refreshMenuItem.addActionListener(e -> {
 			abcFileTreeModel.refresh(sortType);
+			reExpandPaths();
 		});
 	}
 	
 	private void reExpandPaths() {
-		System.out.println(expandedAbcTrees.size() + " expanded trees");
+		HashSet<TreePath> validExpandedTrees = new HashSet<TreePath>();
 		for (TreePath path : expandedAbcTrees) {
 			Object[] nodes = path.getPath();
 			Object walk = abcFileTreeModel.getRoot();
-			System.out.println(walk);
-			System.out.println();
 			boolean found = true;
 			for (Object node : nodes) {
 				if (node == abcFileTreeModel.getRoot()) {
 					continue;
 				}
 				
-				System.out.println(node);
 				int idx = abcFileTreeModel.getIndexOfChild(walk, node);
 				if (idx < 0) {
 					found = false;
@@ -815,8 +827,10 @@ public class AbcPlaylistPanel extends JPanel {
 			}
 			if (found) {
 				abcFileTree.expandPath(path);
+				validExpandedTrees.add(path);
 			}
 		}
+		expandedAbcTrees = validExpandedTrees;
 	}
 	
 	private void initTableHeaderColumns() {

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -763,6 +763,7 @@ public class AbcPlaylistPanel extends JPanel {
 				sortType = type;
 				prefs.put("sortType", sortType.name());
 				abcFileTreeModel.sort(sortType);
+				abcFileTreeModel.filter(searchTextField.getText());
 				reExpandPaths();
 			});
 			group.add(item);

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
+import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
@@ -19,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EventObject;
+import java.util.HashSet;
 import java.util.List;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
@@ -60,6 +62,8 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.event.TableColumnModelEvent;
 import javax.swing.event.TableColumnModelListener;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -79,6 +83,7 @@ import com.digero.common.util.Listener;
 import com.digero.common.util.ParseException;
 import com.digero.common.util.Util;
 import com.digero.common.view.AbcPlaylistTreeCellRenderer;
+import com.digero.common.view.HintTextField;
 import com.digero.maestro.util.XmlUtil;
 
 import net.miginfocom.swing.MigLayout;
@@ -126,8 +131,10 @@ public class AbcPlaylistPanel extends JPanel {
 	// for menu item action listeners
 	private int menuRowIdx = -1;
 	private AbcFileTreeModel abcFileTreeModel;
+	private HashSet<TreePath> expandedAbcTrees;
 	private JScrollPane fileTreeScrollPane;
 	private JButton addToPlaylistButton;
+	private HintTextField searchTextField;
 	
 	// Right
 	private JTable playlistTable;
@@ -202,6 +209,9 @@ public class AbcPlaylistPanel extends JPanel {
 		
 		abcFileTreeModel = new AbcFileTreeModel(topLevelDirs);
 		abcFileTreeModel.refresh(sortType);
+		abcFileTreeModel.filter("");
+		
+		expandedAbcTrees = new HashSet<TreePath>();
 		
 		abcFileTree = new JTree();
 		abcFileTree.setShowsRootHandles(true);
@@ -281,6 +291,17 @@ public class AbcPlaylistPanel extends JPanel {
 				}
 			}
 			addToPlaylistButton.setEnabled(noFoldersSelected);
+		});
+		abcFileTree.addTreeExpansionListener(new TreeExpansionListener() {
+			@Override
+			public void treeCollapsed(TreeExpansionEvent e) {
+				expandedAbcTrees.remove(e.getPath());
+			}
+
+			@Override
+			public void treeExpanded(TreeExpansionEvent e) {
+				expandedAbcTrees.add(e.getPath());	
+			}
 		});
 		JPopupMenu fileTreePopup = new JPopupMenu();
 		
@@ -583,6 +604,21 @@ public class AbcPlaylistPanel extends JPanel {
 			addFilesToPlaylist(treePathsToFileList(abcFileTree.getSelectionPaths()), -1);
 		});
 		
+		searchTextField = new HintTextField("Search...", 15);
+		searchTextField.getDocument().addDocumentListener(new DocumentListener() {
+			@Override
+			public void changedUpdate(DocumentEvent e) { update(e); }
+			@Override
+			public void insertUpdate(DocumentEvent e) { update(e); }
+			@Override
+			public void removeUpdate(DocumentEvent e) { update(e); }
+			
+			public void update(DocumentEvent e) {
+				abcFileTreeModel.filter(searchTextField.getText().toLowerCase());
+				reExpandPaths();
+			}
+		});
+		
 		JButton playPlaylistButton = new JButton("Play");
 		playPlaylistButton.setToolTipText("Play playlist starting from the first song.");
 		playPlaylistButton.setFocusable(false);
@@ -655,6 +691,7 @@ public class AbcPlaylistPanel extends JPanel {
 		
 		bottomControls = new JPanel(new MigLayout("fillx"));
 		bottomControls.add(addToPlaylistButton);
+		bottomControls.add(searchTextField);
 		
 		bottomControls.add(new JPanel(), "pushx 200");
 		
@@ -725,7 +762,8 @@ public class AbcPlaylistPanel extends JPanel {
 			item.addActionListener(e -> {
 				sortType = type;
 				prefs.put("sortType", sortType.name());
-				abcFileTreeModel.refresh(sortType);
+				abcFileTreeModel.sort(sortType);
+				reExpandPaths();
 			});
 			group.add(item);
 			sortBy.add(item);
@@ -751,6 +789,33 @@ public class AbcPlaylistPanel extends JPanel {
 		refreshMenuItem.addActionListener(e -> {
 			abcFileTreeModel.refresh(sortType);
 		});
+	}
+	
+	private void reExpandPaths() {
+		System.out.println(expandedAbcTrees.size() + " expanded trees");
+		for (TreePath path : expandedAbcTrees) {
+			Object[] nodes = path.getPath();
+			Object walk = abcFileTreeModel.getRoot();
+			System.out.println(walk);
+			System.out.println();
+			boolean found = true;
+			for (Object node : nodes) {
+				if (node == abcFileTreeModel.getRoot()) {
+					continue;
+				}
+				
+				System.out.println(node);
+				int idx = abcFileTreeModel.getIndexOfChild(walk, node);
+				if (idx < 0) {
+					found = false;
+				} else {
+					walk = abcFileTreeModel.getChild(walk, idx);
+				}
+			}
+			if (found) {
+				abcFileTree.expandPath(path);
+			}
+		}
 	}
 	
 	private void initTableHeaderColumns() {

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -5,6 +5,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -1207,6 +1208,9 @@ public class AbcPlaylistPanel extends JPanel {
 						for (AbcInfo info : data) {
 							tableModel.addRow(info);
 						}
+						playlistTable.revalidate();
+						Rectangle rect = playlistTable.getCellRect(playlistTable.getRowCount() - 1, 0, true);
+						playlistTable.scrollRectToVisible(rect);
 					} else { // Drag and drop to a specific position
 						int idx = insertPos;
 						for (AbcInfo info : data) {

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -70,7 +70,6 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.tree.TreePath;
 
 import com.digero.abcplayer.AbcPlaylistXmlCoder;
-import com.digero.abcplayer.SetFilenameTemplate;
 import com.digero.abcplayer.view.AbcPlaylistPanel.PlaylistEvent.PlaylistEventType;
 import com.digero.common.abctomidi.AbcInfo;
 import com.digero.common.abctomidi.AbcToMidi;
@@ -751,8 +750,11 @@ public class AbcPlaylistPanel extends JPanel {
 		});
 		exportSetMenuItem = playlistMenu.add(new JMenuItem("Export Playlist as Set..."));
 		exportSetMenuItem.addActionListener(e -> {
-			SetFilenameTemplate template = new SetFilenameTemplate(prefs.node("setExportFilename"));
-			PlaylistSetExportWizard wiz = new PlaylistSetExportWizard((JFrame)SwingUtilities.getWindowAncestor(this), template);
+			PlaylistSetExportWizard wiz = new PlaylistSetExportWizard(
+					(JFrame)SwingUtilities.getWindowAncestor(this),
+					prefs.node("setExport"),
+					playlistFile,
+					tableModel.getTableData());
 			wiz.setVisible(true);
 		});
 		playlistMenu.addSeparator();

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -1,7 +1,15 @@
 package com.digero.abcplayer.view;
 
 import java.awt.BorderLayout;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map.Entry;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -11,26 +19,183 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JProgressBar;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
+import javax.swing.SwingWorker;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import com.digero.abcplayer.SetFilenameTemplate;
+import com.digero.common.abctomidi.AbcInfo;
 import com.digero.common.util.Util;
+import com.digero.maestro.abc.ExportFilenameTemplate;
 
 import net.miginfocom.swing.MigLayout;
 
 public class PlaylistSetExportWizard extends JDialog {
 	
+	public static final String[] spaceReplaceChars = { " ", "", "_", "-" };
+	public static final String[] spaceReplaceLabels = { "Don't Replace", "Remove Spaces", "_ (Underscore)",
+			"- (Dash)" };
+	
+	public static class SetExportSettings {
+		// Main settings
+		private String outputDirectory;
+		private boolean renameAbcFiles;
+		private boolean exportAsZip;
+		private boolean exportPartSheet;
+		
+		// Pattern
+		private String filenamePattern;
+		private String whitespaceReplaceText;
+		private boolean partCountZeroPadded;
+		
+		// CSV part sheet
+		private boolean usePartNames;
+
+		private final Preferences prefs;
+
+		private SetExportSettings(Preferences prefs) {
+			this.prefs = prefs;
+			// General settings
+			outputDirectory = prefs.get("outputDirectory", Util.getLotroMusicPath(false).getAbsolutePath());
+			renameAbcFiles = prefs.getBoolean("renameAbcFiles", true);
+			exportAsZip = prefs.getBoolean("exportAsZip", true);
+			exportPartSheet = prefs.getBoolean("exportPartSheet", false);
+			
+			// Export filename settings
+			filenamePattern = prefs.get("filenamePattern", "$SongIndex_$FileName");
+			whitespaceReplaceText = prefs.get("whitespaceReplaceText", " ");
+			partCountZeroPadded = prefs.getBoolean("partCountZeroPadded", true);
+			
+			// CSV part sheet settings
+			usePartNames = prefs.getBoolean("usePartNames", false);
+		}
+
+		public SetExportSettings(SetExportSettings source) {
+			this.prefs = source.prefs;
+			copyFrom(source);
+		}
+
+		private void save() {
+			prefs.put("outputDirectory", outputDirectory);
+			prefs.putBoolean("renameAbcFiles", renameAbcFiles);
+			prefs.putBoolean("exportAsZip", exportAsZip);
+			prefs.putBoolean("exportPartSheet", exportPartSheet);
+			
+			prefs.put("filenamePattern", filenamePattern);
+			prefs.put("whitespaceReplaceText", whitespaceReplaceText);
+			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
+			
+			prefs.putBoolean("usePartNames", usePartNames);
+		}
+
+		private void copyFrom(SetExportSettings source) {
+			this.filenamePattern = source.filenamePattern;
+			this.whitespaceReplaceText = source.whitespaceReplaceText;
+			this.partCountZeroPadded = source.partCountZeroPadded;
+		}
+		
+		public String getOutputDirectory() {
+			return outputDirectory;
+		}
+
+		public void setOutputDirectory(String outputDirectory) {
+			this.outputDirectory = outputDirectory;
+		}
+
+		public boolean isRenameAbcFiles() {
+			return renameAbcFiles;
+		}
+
+		public void setRenameAbcFiles(boolean renameAbcFiles) {
+			this.renameAbcFiles = renameAbcFiles;
+		}
+
+		public boolean isExportAsZip() {
+			return exportAsZip;
+		}
+
+		public void setExportAsZip(boolean exportAsZip) {
+			this.exportAsZip = exportAsZip;
+		}
+
+		public boolean isExportPartSheet() {
+			return exportPartSheet;
+		}
+
+		public void setExportPartSheet(boolean exportPartSheet) {
+			this.exportPartSheet = exportPartSheet;
+		}
+
+		public String getExportFilenamePattern() {
+			return filenamePattern;
+		}
+
+		public void setExportFilenamePattern(String exportFilenamePattern) {
+			this.filenamePattern = exportFilenamePattern;
+		}
+
+		public String getWhitespaceReplaceText() {
+			return whitespaceReplaceText;
+		}
+
+		public void setWhitespaceReplaceText(String whitespaceReplaceText) {
+			this.whitespaceReplaceText = whitespaceReplaceText;
+		}
+
+		public boolean isPartCountZeroPadded() {
+			return partCountZeroPadded;
+		}
+
+		public void setPartCountZeroPadded(boolean zeroPadded) {
+			partCountZeroPadded = zeroPadded;
+		}
+		
+		public boolean isUsePartNames() {
+			return usePartNames;
+		}
+
+		public void setUsePartNames(boolean usePartNames) {
+			this.usePartNames = usePartNames;
+		}
+
+		public void restoreDefaults() {
+			try {
+				prefs.clear();
+			} catch (BackingStoreException e) {
+				e.printStackTrace();
+			}
+
+			SetExportSettings fresh = new SetExportSettings(prefs);
+			this.copyFrom(fresh);
+		}
+	}
+	
 	private static final long serialVersionUID = -946060522761562397L;
 
 	private JTabbedPane tabPanel;
-	
+	private SetExportSettings settings;
 	private SetFilenameTemplate filenameTemplate;
 	
-	public PlaylistSetExportWizard(JFrame owner, SetFilenameTemplate filenameTemplate) {
+	private JLabel progressLabel;
+	private JProgressBar progressBar;
+	
+	private JTextField setNameField;
+	private JLabel exampleAbcFileLabel;
+	
+	private File playlistFile;
+	private List<AbcInfo> setData;
+	
+	public PlaylistSetExportWizard(JFrame owner, Preferences prefNode, File playlistFile, List<AbcInfo> setData) {
 		super(owner, "Export Set Wizard", true);
 		
-		this.filenameTemplate = filenameTemplate;
+		this.playlistFile = playlistFile;
+		this.setData = setData;
+		
+		settings = new SetExportSettings(prefNode);
+		this.filenameTemplate = new SetFilenameTemplate(settings);
 		
 		tabPanel = new JTabbedPane();
 		tabPanel.addTab("Export Settings", createExportPanel());
@@ -40,7 +205,7 @@ public class PlaylistSetExportWizard extends JDialog {
 		JButton exportButton = new JButton("Export");
 		getRootPane().setDefaultButton(exportButton);
 		exportButton.addActionListener(e -> {
-			
+			new SetExportWorker(setNameField.getText()).execute();
 		});
 		
 		JButton cancelButton = new JButton("Cancel");
@@ -48,11 +213,16 @@ public class PlaylistSetExportWizard extends JDialog {
 			this.setVisible(false);
 		});
 		
+		progressLabel = new JLabel();
+		progressBar = new JProgressBar();
+		
 		JPanel buttonsPanel = new JPanel(new MigLayout("fillx"));
-		buttonsPanel.add(new JLabel(), "growx 0");
+		buttonsPanel.add(progressLabel, "span 4, grow, wrap");
+		buttonsPanel.add(progressBar, "span 4, grow, wrap");
+		buttonsPanel.add(new JLabel(), "growx -1");
 		buttonsPanel.add(cancelButton, "align right");
 		buttonsPanel.add(exportButton, "align left");
-		buttonsPanel.add(new JLabel(), "growx 0");
+		buttonsPanel.add(new JLabel(), "growx -1");
 		
 		JPanel mainPanel = new JPanel(new BorderLayout());
 		mainPanel.add(tabPanel, BorderLayout.CENTER);
@@ -61,35 +231,67 @@ public class PlaylistSetExportWizard extends JDialog {
 		setContentPane(mainPanel);
 		pack();
 		setLocationRelativeTo(owner);
+		
+		updateFilenameExample();
 	}
 	
 	private JPanel createExportPanel() {
-		JPanel exportPanel = new JPanel(new MigLayout("fillx"));
+		JPanel exportPanel = new JPanel(new MigLayout("fillx", "[grow -1][]"));
+		
+		JLabel directoryLabel = new JLabel(settings.getOutputDirectory());
 		
 		JButton chooseDirectoryButton = new JButton("Output Folder...");
 		chooseDirectoryButton.addActionListener(e -> {
 			JFileChooser chooser = new JFileChooser();
-			chooser.setDialogTitle("Open set destination folder");
-			chooser.showOpenDialog(this);
+			chooser.setApproveButtonText("Select");
+			chooser.setCurrentDirectory(new File(directoryLabel.getText()));
+			chooser.setDialogTitle("Select Set Destination");
+			chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+			chooser.setMultiSelectionEnabled(false);
+			if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+				String dir = chooser.getSelectedFile().toString();
+				directoryLabel.setText(dir);
+				settings.setOutputDirectory(dir);
+			}
 		});
-		JLabel directoryLabel = new JLabel(Util.getLotroMusicPath(false).toString());
 		
 		JLabel setNameLabel = new JLabel("Set Name:");
-		JTextField setNameField = new JTextField();
+		String setName = "Untitled Set";
+		if (playlistFile != null) {
+			setName = playlistFile.getName();
+			if (setName.contains(".")) {
+				setName = setName.substring(0, setName.lastIndexOf('.'));
+			}
+		}
+		setNameField = new JTextField(setName);
 		
 		JCheckBox exportAsZip = new JCheckBox("Export As Zip");
+		exportAsZip.setSelected(settings.isExportAsZip());
+		exportAsZip.addActionListener(e -> {
+			settings.setExportAsZip(exportAsZip.isSelected());
+		});
 		
-		JCheckBox includeCsvPartsheet = new JCheckBox("Export CSV Part Sheet");
+		JCheckBox exportCsvPartsheet = new JCheckBox("Export CSV Part Sheet");
+		exportCsvPartsheet.setSelected(settings.isExportPartSheet());
+		exportCsvPartsheet.addActionListener(e -> {
+			settings.setExportPartSheet(exportCsvPartsheet.isSelected());
+		});
 		
-		exportPanel.add(chooseDirectoryButton);
-		exportPanel.add(directoryLabel, "wrap");
+		JCheckBox renameAbcFiles = new JCheckBox("Rename ABCs using Pattern");
+		renameAbcFiles.setSelected(settings.isRenameAbcFiles());
+		renameAbcFiles.addActionListener(e -> {
+			settings.setRenameAbcFiles(renameAbcFiles.isSelected());
+		});
 		
-		exportPanel.add(setNameLabel, "align r");
-		exportPanel.add(setNameField, "grow x, wrap");
-
+		exportPanel.add(chooseDirectoryButton, "align r");
+		exportPanel.add(directoryLabel, "growx, wrap");
+		
+		exportPanel.add(setNameLabel, "shrink, align r");
+		exportPanel.add(setNameField, "growx, wrap");
+		
+		exportPanel.add(renameAbcFiles, "span 2, wrap");
 		exportPanel.add(exportAsZip, "span 2, wrap");
-		
-		exportPanel.add(includeCsvPartsheet, "span 2");
+		exportPanel.add(exportCsvPartsheet, "span 2");
 		
 		return exportPanel;
 	}
@@ -97,16 +299,61 @@ public class PlaylistSetExportWizard extends JDialog {
 	private JPanel createFileNamingPanel() {
 		JPanel fileNamePanel = new JPanel(new MigLayout("fillx"));
 		
+		JLabel whitespaceLabel = new JLabel("<html><b>Replace spaces in variables with:</b></html>");
+		
+		JComboBox<String> replaceWhitespaceComboBox = new JComboBox<>(ExportFilenameTemplate.spaceReplaceLabels);
+		String replaceText = settings.getWhitespaceReplaceText();
+		int selectedIndex = 0;
+		settings.setWhitespaceReplaceText(spaceReplaceChars[0]);
+
+		for (int i = 0; i < ExportFilenameTemplate.spaceReplaceChars.length; i++) {
+			if (replaceText.equals(ExportFilenameTemplate.spaceReplaceChars[i])) {
+				settings.setWhitespaceReplaceText(ExportFilenameTemplate.spaceReplaceChars[i]);
+				selectedIndex = i;
+			}
+		}
+		replaceWhitespaceComboBox.setSelectedIndex(selectedIndex);
+		replaceWhitespaceComboBox.addActionListener(e -> {
+			settings.setWhitespaceReplaceText(
+					ExportFilenameTemplate.spaceReplaceChars[replaceWhitespaceComboBox.getSelectedIndex()]);
+			updateFilenameExample();
+		});
+		
 		JLabel patternLabel = new JLabel("<html><b><u>Pattern for new ABC filenames</b></u></html>");
 		
-		JTextField patternTextField = new JTextField();
+		JTextField patternTextField = new JTextField(settings.getExportFilenamePattern(), 40);
+		patternTextField.getDocument().addDocumentListener(new DocumentListener() {
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				update();
+			}
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				update();
+			}
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				update();
+			}
+			public void update() {
+				settings.setExportFilenamePattern(patternTextField.getText());
+				updateFilenameExample();
+			}
+		});
+		
+		exampleAbcFileLabel = new JLabel(".abc");
 		
 		JLabel nameLabel = new JLabel("<html><u><b>Variable Name</b></u></html");
 		JLabel exampleLabel = new JLabel("<html><u><b>Example</b></u></html>");
 		
+		fileNamePanel.add(whitespaceLabel);
+		fileNamePanel.add(replaceWhitespaceComboBox, "grow x, wrap");
+		
 		fileNamePanel.add(patternLabel, "grow x, span 2, wrap");
 		
 		fileNamePanel.add(patternTextField, "grow x, span 2, wrap");
+		
+		fileNamePanel.add(exampleAbcFileLabel, "grow x, span 2, wrap");
 		
 		fileNamePanel.add(nameLabel);
 		fileNamePanel.add(exampleLabel, "wrap");
@@ -121,6 +368,12 @@ public class PlaylistSetExportWizard extends JDialog {
 		return fileNamePanel;
 	}
 	
+	private void updateFilenameExample() {
+		String exampleText = filenameTemplate.formatName(settings);
+		exampleText = "Example filename:   " + exampleText;
+		exampleAbcFileLabel.setText(exampleText);
+	}
+	
 	private JPanel createPartSheetPanel() {
 		JPanel partSheetPanel = new JPanel(new MigLayout());
 		
@@ -133,5 +386,174 @@ public class PlaylistSetExportWizard extends JDialog {
 		partSheetPanel.add(partContentChoice, "wrap");
 		
 		return partSheetPanel;
+	}
+	
+	private static class SetExportProgress {
+		public int progress;
+		public String message;
+		
+		public SetExportProgress(int i, String s) {
+			progress = i;
+			message = s;
+		}
+	}
+	
+	private class SetExportWorker extends SwingWorker<Boolean, SetExportProgress> {
+		
+		private String setName;
+		private File copyToFolder;
+		private String error;
+		
+		public SetExportWorker(String setName) {
+			this.setName = setName;
+		}
+		
+		// Begin thread processing methods, DONT touch Swing components
+		
+		// Test for existence of output folder or output zip and fail if it exists
+		// Create output folder or create temp folder to zip
+		private boolean initializeOutput() {
+			String outputFolder = settings.outputDirectory;
+			System.out.println("HERE");
+			
+			if (settings.exportAsZip) {
+				Path tempDir;
+				String zipName = setName + ".zip";
+				File zipFile = Paths.get(outputFolder, zipName).toFile();
+				System.out.println("HERE2 " + zipFile.toString());
+				if (zipFile.exists()) {
+					error = "Set output zip file '" + zipName +"' already exists in the target directory";
+					return false;
+				}
+				System.out.println("HERE33");
+				try {
+					tempDir = Files.createTempDirectory("setExport");
+				} catch (IOException e) {
+					error = "Failed to create ABC export directory";
+					System.out.println("FAILED HERE");
+					return false;
+				}
+				System.out.println("HERE3");
+				copyToFolder = Paths.get(tempDir.toString(), setName).toFile();
+				System.out.println("HERE4");
+			} else {
+				copyToFolder = Paths.get(outputFolder, setName).toFile();
+				if (copyToFolder.exists()) {
+					error = "Set output folder '" + setName + "' already exists in the target directory";
+					return false;
+				}
+			}
+			
+			try {
+				Files.createDirectory(copyToFolder.toPath());
+			} catch (IOException e) {
+				error = "Failed to create ABC export directory";
+				return false;
+			}
+			
+			System.out.println("Created copy to folder: " + copyToFolder.toString());
+			
+			publish(new SetExportProgress(10, "Created destination folder..."));
+			
+			return true;
+		}
+		
+		private boolean copyAbcFilesToSet() {
+			int count = setData.size();
+			float inc = 70.f / (float)count;
+			float progress = 10;
+			for (int i = 0; i < count; i++) {
+				AbcInfo inf = setData.get(i);
+				filenameTemplate.setAbcInfo(inf);
+				filenameTemplate.setIndex(i);
+				filenameTemplate.setFilename(inf.getSourceFiles().get(0).getName());
+				String newName = filenameTemplate.formatName(settings);
+				Path source = inf.getSourceFiles().get(0).toPath();
+				Path dest = copyToFolder.toPath().resolve(newName);
+				System.out.println("src:" + source.toString() + " dst:" + dest.toString() + " i:" + i);
+				try {
+					Files.copy(source, dest);
+				} catch (IOException e) {
+					e.printStackTrace();
+					error = "Failed to copy abc file '" + source.getFileName() + "' to set directory";
+					return false;
+				}
+				progress += inc;
+				publish(new SetExportProgress((int)progress, "Copied file " + (i + 1) + " of " + count + "..."));
+			}
+			
+			return true;
+		}
+		
+		private boolean generateCsvPartSheetIfNeeded() {
+			return true;
+		}
+		
+		private boolean zipSetIfNeeded() {
+			if (!settings.exportAsZip) {
+				return true;
+			}
+			
+			
+			
+			return true;
+		}
+		
+		@Override
+		protected Boolean doInBackground() throws Exception {
+			
+			boolean success = initializeOutput();
+			if (!success) {
+				// TODO: Error
+				System.out.println(error);
+				return false;
+			}
+			System.out.println("Init output S");
+			Thread.sleep(50);
+			
+			success = copyAbcFilesToSet();
+			if (!success) {
+				System.out.println(error);
+				return false;
+			}
+			System.out.println("Copy ABC S");
+			
+			success = generateCsvPartSheetIfNeeded();
+			if (!success) {
+				System.out.println(error);
+				return false;
+			}
+			System.out.println("Part sheet S");
+			
+			success = zipSetIfNeeded();
+			if (!success) {
+				System.out.println(error);
+				return false;
+			}
+			System.out.println("Zip S");
+			
+			return true;
+		}
+		
+		// End thread processing methods
+		
+		@Override
+		protected void process(List<SetExportProgress> chunks) {
+			super.process(chunks);
+			
+			SetExportProgress p = chunks.get(chunks.size() - 1);
+			progressBar.setValue(p.progress);
+			progressLabel.setText(p.message);
+		}
+
+		@Override
+		protected void done() {
+			super.done();
+			
+			System.out.println(error);
+			
+			progressBar.setValue(0);
+			progressLabel.setText(error);
+		}
 	}
 }

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -1,0 +1,7 @@
+package com.digero.abcplayer.view;
+
+import javax.swing.JFrame;
+
+public class PlaylistSetExportWizard extends JFrame {
+	
+}

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -646,7 +646,7 @@ public class PlaylistSetExportWizard extends JDialog {
 			try {
 				Path zipPath = Files.createFile(zipFile.toPath());
 				try(ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(zipPath))) {
-					Path copyPath = copyToFolder.toPath();
+					Path copyPath = copyToFolder.getParentFile().toPath();
 					Files.walk(copyPath)
 						.filter(path -> !Files.isDirectory(path))
 						.forEach(path -> {

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -5,7 +5,9 @@ import java.util.Map.Entry;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JDialog;
+import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -19,6 +21,8 @@ import net.miginfocom.swing.MigLayout;
 
 public class PlaylistSetExportWizard extends JDialog {
 	
+	private static final long serialVersionUID = -946060522761562397L;
+
 	private JTabbedPane tabPanel;
 	
 	private SetFilenameTemplate filenameTemplate;
@@ -30,12 +34,19 @@ public class PlaylistSetExportWizard extends JDialog {
 		
 		tabPanel = new JTabbedPane();
 		tabPanel.addTab("Export Settings", createExportPanel());
-		tabPanel.addTab("File Naming", createFileNamingPanel());
+		tabPanel.addTab("ABC File Renaming", createFileNamingPanel());
 		tabPanel.addTab("CSV Part Sheet", createPartSheetPanel());
 		
 		JButton exportButton = new JButton("Export");
+		getRootPane().setDefaultButton(exportButton);
+		exportButton.addActionListener(e -> {
+			
+		});
 		
 		JButton cancelButton = new JButton("Cancel");
+		cancelButton.addActionListener(e -> {
+			this.setVisible(false);
+		});
 		
 		JPanel buttonsPanel = new JPanel(new MigLayout("fillx"));
 		buttonsPanel.add(new JLabel(), "growx 0");
@@ -53,9 +64,14 @@ public class PlaylistSetExportWizard extends JDialog {
 	}
 	
 	private JPanel createExportPanel() {
-		JPanel exportPanel = new JPanel(new MigLayout());
+		JPanel exportPanel = new JPanel(new MigLayout("fillx"));
 		
 		JButton chooseDirectoryButton = new JButton("Output Folder...");
+		chooseDirectoryButton.addActionListener(e -> {
+			JFileChooser chooser = new JFileChooser();
+			chooser.setDialogTitle("Open set destination folder");
+			chooser.showOpenDialog(this);
+		});
 		JLabel directoryLabel = new JLabel(Util.getLotroMusicPath(false).toString());
 		
 		JLabel setNameLabel = new JLabel("Set Name:");
@@ -81,7 +97,7 @@ public class PlaylistSetExportWizard extends JDialog {
 	private JPanel createFileNamingPanel() {
 		JPanel fileNamePanel = new JPanel(new MigLayout("fillx"));
 		
-		JLabel patternLabel = new JLabel("<html><b><u>Pattern for ABC File Name</b></u></html>");
+		JLabel patternLabel = new JLabel("<html><b><u>Pattern for new ABC filenames</b></u></html>");
 		
 		JTextField patternTextField = new JTextField();
 		
@@ -107,6 +123,14 @@ public class PlaylistSetExportWizard extends JDialog {
 	
 	private JPanel createPartSheetPanel() {
 		JPanel partSheetPanel = new JPanel(new MigLayout());
+		
+		JLabel partChoiceLabel = new JLabel("Part column content:");
+		
+		String[] partContentOptions = {"Use Part Names", "Use Instrument Names"};
+		JComboBox<String> partContentChoice = new JComboBox<String>(partContentOptions);
+		
+		partSheetPanel.add(partChoiceLabel);
+		partSheetPanel.add(partContentChoice, "wrap");
 		
 		return partSheetPanel;
 	}

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -2,14 +2,18 @@ package com.digero.abcplayer.view;
 
 import java.awt.BorderLayout;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -18,6 +22,7 @@ import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JTabbedPane;
@@ -25,6 +30,9 @@ import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 
 import com.digero.abcplayer.SetFilenameTemplate;
 import com.digero.common.abctomidi.AbcInfo;
@@ -53,6 +61,9 @@ public class PlaylistSetExportWizard extends JDialog {
 		
 		// CSV part sheet
 		private boolean usePartNames;
+		private boolean columnDuration;
+		private boolean columnComposer;
+		private boolean columnTranscriber;
 
 		private final Preferences prefs;
 
@@ -71,6 +82,9 @@ public class PlaylistSetExportWizard extends JDialog {
 			
 			// CSV part sheet settings
 			usePartNames = prefs.getBoolean("usePartNames", false);
+			columnDuration = prefs.getBoolean("columnDuration", true);
+			columnComposer = prefs.getBoolean("columnComposer", false);
+			columnTranscriber = prefs.getBoolean("columnTranscriber", false);
 		}
 
 		public SetExportSettings(SetExportSettings source) {
@@ -89,12 +103,23 @@ public class PlaylistSetExportWizard extends JDialog {
 			prefs.putBoolean("partCountZeroPadded", partCountZeroPadded);
 			
 			prefs.putBoolean("usePartNames", usePartNames);
+			prefs.putBoolean("columnDuration", columnDuration);
+			prefs.putBoolean("columnComposer", columnComposer);
+			prefs.putBoolean("columnTranscriber", columnTranscriber);
 		}
 
 		private void copyFrom(SetExportSettings source) {
+			this.outputDirectory = source.outputDirectory;
+			this.renameAbcFiles = source.renameAbcFiles;
+			this.exportAsZip = source.exportAsZip;
+			this.exportPartSheet = source.exportPartSheet;
 			this.filenamePattern = source.filenamePattern;
 			this.whitespaceReplaceText = source.whitespaceReplaceText;
 			this.partCountZeroPadded = source.partCountZeroPadded;
+			this.usePartNames = source.usePartNames;
+			this.columnDuration = source.columnDuration;
+			this.columnComposer = source.columnComposer;
+			this.columnTranscriber = source.columnTranscriber;
 		}
 		
 		public String getOutputDirectory() {
@@ -159,6 +184,30 @@ public class PlaylistSetExportWizard extends JDialog {
 
 		public void setUsePartNames(boolean usePartNames) {
 			this.usePartNames = usePartNames;
+		}
+		
+		public boolean isColumnDuration() {
+			return columnDuration;
+		}
+
+		public void setColumnDuration(boolean columnDuration) {
+			this.columnDuration = columnDuration;
+		}
+
+		public boolean isColumnComposer() {
+			return columnComposer;
+		}
+
+		public void setColumnComposer(boolean columnComposer) {
+			this.columnComposer = columnComposer;
+		}
+
+		public boolean isColumnTranscriber() {
+			return columnTranscriber;
+		}
+
+		public void setColumnTranscriber(boolean columnTranscriber) {
+			this.columnTranscriber = columnTranscriber;
 		}
 
 		public void restoreDefaults() {
@@ -239,8 +288,10 @@ public class PlaylistSetExportWizard extends JDialog {
 		JPanel exportPanel = new JPanel(new MigLayout("fillx", "[grow -1][]"));
 		
 		JLabel directoryLabel = new JLabel(settings.getOutputDirectory());
+		directoryLabel.setToolTipText("Directory in which the set folder or zip will be exported.");
 		
 		JButton chooseDirectoryButton = new JButton("Output Folder...");
+		chooseDirectoryButton.setToolTipText("Choose the directory in which the set folder or zip will be exported.");
 		chooseDirectoryButton.addActionListener(e -> {
 			JFileChooser chooser = new JFileChooser();
 			chooser.setApproveButtonText("Select");
@@ -256,6 +307,7 @@ public class PlaylistSetExportWizard extends JDialog {
 		});
 		
 		JLabel setNameLabel = new JLabel("Set Name:");
+		setNameLabel.setToolTipText("The set will be exported into a folder or a zip file with this name.");
 		String setName = "Untitled Set";
 		if (playlistFile != null) {
 			setName = playlistFile.getName();
@@ -264,20 +316,24 @@ public class PlaylistSetExportWizard extends JDialog {
 			}
 		}
 		setNameField = new JTextField(setName);
+		setNameField.setToolTipText("The set will be exported into a folder or a zip file with this name.");
 		
 		JCheckBox exportAsZip = new JCheckBox("Export As Zip");
+		exportAsZip.setToolTipText("If selected, the set will be exported as a zip file rather than into a folder.");
 		exportAsZip.setSelected(settings.isExportAsZip());
 		exportAsZip.addActionListener(e -> {
 			settings.setExportAsZip(exportAsZip.isSelected());
 		});
 		
 		JCheckBox exportCsvPartsheet = new JCheckBox("Export CSV Part Sheet");
+		exportCsvPartsheet.setToolTipText("<html>If selected, a CSV part sheet will be generated alongside the ABC files.<br>See the CSV Part Sheet tab for related options.</html>");
 		exportCsvPartsheet.setSelected(settings.isExportPartSheet());
 		exportCsvPartsheet.addActionListener(e -> {
 			settings.setExportPartSheet(exportCsvPartsheet.isSelected());
 		});
 		
-		JCheckBox renameAbcFiles = new JCheckBox("Rename ABCs using Pattern");
+		JCheckBox renameAbcFiles = new JCheckBox("Rename ABC Files using Pattern");
+		renameAbcFiles.setToolTipText("<html>If selected, ABC files will be renamed and reordered in the exported set<br>according to the pattern specified in the ABC File Renaming tab.</html>");
 		renameAbcFiles.setSelected(settings.isRenameAbcFiles());
 		renameAbcFiles.addActionListener(e -> {
 			settings.setRenameAbcFiles(renameAbcFiles.isSelected());
@@ -377,13 +433,34 @@ public class PlaylistSetExportWizard extends JDialog {
 	private JPanel createPartSheetPanel() {
 		JPanel partSheetPanel = new JPanel(new MigLayout());
 		
-		JLabel partChoiceLabel = new JLabel("Part column content:");
+		JLabel partChoiceLabel = new JLabel("Part columns content:");
 		
 		String[] partContentOptions = {"Use Part Names", "Use Instrument Names"};
 		JComboBox<String> partContentChoice = new JComboBox<String>(partContentOptions);
 		
+		JLabel columnLabel = new JLabel("<html><u><b>Extra Columns</b></u></html");
+		JCheckBox durationColumn = new JCheckBox("Song Duration");
+		durationColumn.setSelected(settings.isColumnDuration());
+		durationColumn.addActionListener(e -> {
+			settings.setColumnDuration(durationColumn.isSelected());
+		});
+		JCheckBox composerColumn = new JCheckBox("Composer");
+		composerColumn.setSelected(settings.isColumnComposer());
+		composerColumn.addActionListener(e -> {
+			settings.setColumnComposer(composerColumn.isSelected());
+		});
+		JCheckBox transcriberColumn = new JCheckBox("Transcriber");
+		transcriberColumn.setSelected(settings.isColumnTranscriber());
+		transcriberColumn.addActionListener(e -> {
+			settings.setColumnTranscriber(transcriberColumn.isSelected());
+		});
+		
 		partSheetPanel.add(partChoiceLabel);
 		partSheetPanel.add(partContentChoice, "wrap");
+		partSheetPanel.add(columnLabel, "span 2, wrap");
+		partSheetPanel.add(durationColumn, "span 2, wrap");
+		partSheetPanel.add(composerColumn, "span 2, wrap");
+		partSheetPanel.add(transcriberColumn, "span 2");
 		
 		return partSheetPanel;
 	}
@@ -402,10 +479,12 @@ public class PlaylistSetExportWizard extends JDialog {
 		
 		private String setName;
 		private File copyToFolder;
-		private String error;
+		private String error = "";
+		private File zipFile;
 		
 		public SetExportWorker(String setName) {
 			this.setName = setName;
+			progressBar.setValue(0);
 		}
 		
 		// Begin thread processing methods, DONT touch Swing components
@@ -419,27 +498,22 @@ public class PlaylistSetExportWizard extends JDialog {
 			if (settings.exportAsZip) {
 				Path tempDir;
 				String zipName = setName + ".zip";
-				File zipFile = Paths.get(outputFolder, zipName).toFile();
-				System.out.println("HERE2 " + zipFile.toString());
+				zipFile = Paths.get(outputFolder, zipName).toFile();
 				if (zipFile.exists()) {
-					error = "Set output zip file '" + zipName +"' already exists in the target directory";
+					error = "Set output zip file already exists";
 					return false;
 				}
-				System.out.println("HERE33");
 				try {
 					tempDir = Files.createTempDirectory("setExport");
 				} catch (IOException e) {
 					error = "Failed to create ABC export directory";
-					System.out.println("FAILED HERE");
 					return false;
 				}
-				System.out.println("HERE3");
 				copyToFolder = Paths.get(tempDir.toString(), setName).toFile();
-				System.out.println("HERE4");
 			} else {
 				copyToFolder = Paths.get(outputFolder, setName).toFile();
 				if (copyToFolder.exists()) {
-					error = "Set output folder '" + setName + "' already exists in the target directory";
+					error = "Set output folder already exists";
 					return false;
 				}
 			}
@@ -458,19 +532,22 @@ public class PlaylistSetExportWizard extends JDialog {
 			return true;
 		}
 		
+		private String getFormattedName(AbcInfo inf, int i) {
+			filenameTemplate.setAbcInfo(inf);
+			filenameTemplate.setIndex(i);
+			filenameTemplate.setFilename(inf.getSourceFiles().get(0).getName());
+			return filenameTemplate.formatName(settings);
+		}
+		
 		private boolean copyAbcFilesToSet() {
 			int count = setData.size();
 			float inc = 70.f / (float)count;
 			float progress = 10;
 			for (int i = 0; i < count; i++) {
 				AbcInfo inf = setData.get(i);
-				filenameTemplate.setAbcInfo(inf);
-				filenameTemplate.setIndex(i);
-				filenameTemplate.setFilename(inf.getSourceFiles().get(0).getName());
-				String newName = filenameTemplate.formatName(settings);
+				String newName = getFormattedName(inf, i);
 				Path source = inf.getSourceFiles().get(0).toPath();
 				Path dest = copyToFolder.toPath().resolve(newName);
-				System.out.println("src:" + source.toString() + " dst:" + dest.toString() + " i:" + i);
 				try {
 					Files.copy(source, dest);
 				} catch (IOException e) {
@@ -479,58 +556,146 @@ public class PlaylistSetExportWizard extends JDialog {
 					return false;
 				}
 				progress += inc;
-				publish(new SetExportProgress((int)progress, "Copied file " + (i + 1) + " of " + count + "..."));
+				publish(new SetExportProgress((int)progress, "Copied ABC " + (i + 1) + " of " + count + "..."));
 			}
 			
 			return true;
 		}
 		
 		private boolean generateCsvPartSheetIfNeeded() {
+			if (!settings.exportPartSheet) {
+				publish(new SetExportProgress(90, "No CSV part sheet needed"));
+				return true;
+			}
+			
+			List<String> headerList = new ArrayList<>();
+			headerList.add("Filename");
+			
+			if (settings.columnDuration) headerList.add("Song Length");
+			if (settings.columnComposer) headerList.add("Composer");
+			if (settings.columnTranscriber) headerList.add("Transcriber");
+			
+			int maxPartCount = 0;
+			
+			for (AbcInfo inf : setData) {
+				if (maxPartCount < inf.getPartCount()) {
+					maxPartCount = inf.getPartCount();
+				}
+			}
+			
+			for (int i = 0; i < maxPartCount; i++) {
+				headerList.add("Part " + (i + 1));
+			}
+			
+			String[] headers = headerList.toArray(new String[0]);
+			CSVFormat format = CSVFormat.DEFAULT.builder().setHeader(headers).get();
+			
+			try {
+				Path csvPath = copyToFolder.toPath().resolve(setName + ".csv");
+				FileWriter out = new FileWriter(csvPath.toFile());
+				try(CSVPrinter printer = new CSVPrinter(out, format)) {
+					for (int i = 0; i < setData.size(); i++) {
+						AbcInfo inf = setData.get(i);
+						List<Object> record = new ArrayList<Object>();
+						
+						// Song file name
+						if (settings.renameAbcFiles) {
+							record.add(getFormattedName(inf, i));
+						} else {
+							record.add(inf.getSourceFiles().get(0).getName());
+						}
+						
+						// Conditional fields
+						if (settings.columnDuration) {
+							record.add(inf.getSongDurationStr());
+						}
+						if (settings.columnComposer) {
+							record.add(inf.getComposer());
+						}
+						if (settings.columnTranscriber) {
+							record.add(inf.getTranscriber());
+						}
+						
+						// Parts
+						for (int j = 0; j < inf.getPartCount(); j++ ) {
+							String name = inf.getPartInstrument(j + 1).friendlyName;
+							if (settings.usePartNames) {
+								name = inf.getPartFullName(j + 1);
+							}
+							record.add(name);
+						}
+						printer.printRecord(record);
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+				return false;
+			}
+			
+			publish(new SetExportProgress(90, "Generated CSV part sheet"));
+			
 			return true;
 		}
 		
 		private boolean zipSetIfNeeded() {
 			if (!settings.exportAsZip) {
+				publish(new SetExportProgress(100, "No zipping needed"));
 				return true;
 			}
 			
+			try {
+				Path zipPath = Files.createFile(zipFile.toPath());
+				try(ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+					Path copyPath = copyToFolder.toPath();
+					Files.walk(copyPath)
+						.filter(path -> !Files.isDirectory(path))
+						.forEach(path -> {
+							ZipEntry zi = new ZipEntry(copyPath.relativize(path).toString());
+							try {
+								zs.putNextEntry(zi);
+								Files.copy(path, zs);
+								zs.closeEntry();
+							} catch (IOException e) {
+								error = "Failed to zip the set";
+							}
+						});
+				}
+			} catch (Exception e) {
+				error = "Failed to zip the set";
+				e.printStackTrace();
+				return false;
+			}
 			
+			if (!error.isEmpty()) {
+				return false;
+			}
+			
+			publish(new SetExportProgress(100, "Zipped the set"));
 			
 			return true;
 		}
 		
 		@Override
 		protected Boolean doInBackground() throws Exception {
-			
 			boolean success = initializeOutput();
 			if (!success) {
-				// TODO: Error
-				System.out.println(error);
 				return false;
 			}
-			System.out.println("Init output S");
-			Thread.sleep(50);
 			
 			success = copyAbcFilesToSet();
 			if (!success) {
-				System.out.println(error);
 				return false;
 			}
-			System.out.println("Copy ABC S");
 			
 			success = generateCsvPartSheetIfNeeded();
 			if (!success) {
-				System.out.println(error);
 				return false;
 			}
-			System.out.println("Part sheet S");
 			
 			success = zipSetIfNeeded();
 			if (!success) {
-				System.out.println(error);
 				return false;
 			}
-			System.out.println("Zip S");
 			
 			return true;
 		}
@@ -550,10 +715,13 @@ public class PlaylistSetExportWizard extends JDialog {
 		protected void done() {
 			super.done();
 			
-			System.out.println(error);
-			
-			progressBar.setValue(0);
-			progressLabel.setText(error);
+			if (!error.isEmpty()) {
+				progressLabel.setText(error);
+				JOptionPane.showMessageDialog(PlaylistSetExportWizard.this, error, "Export Error", JOptionPane.ERROR_MESSAGE);
+			} else {
+				progressLabel.setText("Set export finished");
+				settings.save();
+			}
 		}
 	}
 }

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -1,7 +1,113 @@
 package com.digero.abcplayer.view;
 
-import javax.swing.JFrame;
+import java.awt.BorderLayout;
+import java.util.Map.Entry;
 
-public class PlaylistSetExportWizard extends JFrame {
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
+
+import com.digero.abcplayer.SetFilenameTemplate;
+import com.digero.common.util.Util;
+
+import net.miginfocom.swing.MigLayout;
+
+public class PlaylistSetExportWizard extends JDialog {
 	
+	private JTabbedPane tabPanel;
+	
+	private SetFilenameTemplate filenameTemplate;
+	
+	public PlaylistSetExportWizard(JFrame owner, SetFilenameTemplate filenameTemplate) {
+		super(owner, "Export Set Wizard", true);
+		
+		this.filenameTemplate = filenameTemplate;
+		
+		tabPanel = new JTabbedPane();
+		tabPanel.addTab("Export Settings", createExportPanel());
+		tabPanel.addTab("File Naming", createFileNamingPanel());
+		tabPanel.addTab("CSV Part Sheet", createPartSheetPanel());
+		
+		JButton exportButton = new JButton("Export");
+		
+		JButton cancelButton = new JButton("Cancel");
+		
+		JPanel buttonsPanel = new JPanel(new MigLayout("fillx"));
+		buttonsPanel.add(new JLabel(), "growx 0");
+		buttonsPanel.add(cancelButton, "align right");
+		buttonsPanel.add(exportButton, "align left");
+		buttonsPanel.add(new JLabel(), "growx 0");
+		
+		JPanel mainPanel = new JPanel(new BorderLayout());
+		mainPanel.add(tabPanel, BorderLayout.CENTER);
+		mainPanel.add(buttonsPanel, BorderLayout.SOUTH);
+		
+		setContentPane(mainPanel);
+		pack();
+		setLocationRelativeTo(owner);
+	}
+	
+	private JPanel createExportPanel() {
+		JPanel exportPanel = new JPanel(new MigLayout());
+		
+		JButton chooseDirectoryButton = new JButton("Output Folder...");
+		JLabel directoryLabel = new JLabel(Util.getLotroMusicPath(false).toString());
+		
+		JLabel setNameLabel = new JLabel("Set Name:");
+		JTextField setNameField = new JTextField();
+		
+		JCheckBox exportAsZip = new JCheckBox("Export As Zip");
+		
+		JCheckBox includeCsvPartsheet = new JCheckBox("Export CSV Part Sheet");
+		
+		exportPanel.add(chooseDirectoryButton);
+		exportPanel.add(directoryLabel, "wrap");
+		
+		exportPanel.add(setNameLabel, "align r");
+		exportPanel.add(setNameField, "grow x, wrap");
+
+		exportPanel.add(exportAsZip, "span 2, wrap");
+		
+		exportPanel.add(includeCsvPartsheet, "span 2");
+		
+		return exportPanel;
+	}
+	
+	private JPanel createFileNamingPanel() {
+		JPanel fileNamePanel = new JPanel(new MigLayout("fillx"));
+		
+		JLabel patternLabel = new JLabel("<html><b><u>Pattern for ABC File Name</b></u></html>");
+		
+		JTextField patternTextField = new JTextField();
+		
+		JLabel nameLabel = new JLabel("<html><u><b>Variable Name</b></u></html");
+		JLabel exampleLabel = new JLabel("<html><u><b>Example</b></u></html>");
+		
+		fileNamePanel.add(patternLabel, "grow x, span 2, wrap");
+		
+		fileNamePanel.add(patternTextField, "grow x, span 2, wrap");
+		
+		fileNamePanel.add(nameLabel);
+		fileNamePanel.add(exampleLabel, "wrap");
+		
+		for(Entry<String, SetFilenameTemplate.Variable> entry : filenameTemplate.getVariables().entrySet()) {
+			JLabel keyLabel = new JLabel(entry.getKey());
+			JLabel descriptionLabel = new JLabel(entry.getValue().getValue());
+			fileNamePanel.add(keyLabel);
+			fileNamePanel.add(descriptionLabel, "wrap");
+		}
+		
+		return fileNamePanel;
+	}
+	
+	private JPanel createPartSheetPanel() {
+		JPanel partSheetPanel = new JPanel(new MigLayout());
+		
+		return partSheetPanel;
+	}
 }

--- a/src/com/digero/common/abctomidi/AbcInfo.java
+++ b/src/com/digero/common/abctomidi/AbcInfo.java
@@ -183,7 +183,7 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 	}
 
 	public String getSongDurationStr() {
-		return songDuration;
+		return Util.emptyIfNull(songDuration);
 	}
 
 	public int getPartNumber(int trackIndex) {
@@ -521,5 +521,19 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 			}
 		}
 		return a;
+	}
+	
+	// used for set exporter
+	public static AbcInfo getDummyAbcInfo() {
+		AbcInfo inf = new AbcInfo();
+		inf.setExtendedMetadata(AbcField.SONG_DURATION, "3:14");
+		inf.setExtendedMetadata(AbcField.SONG_TITLE, "Example Title");
+		inf.setExtendedMetadata(AbcField.SONG_COMPOSER, "Example Composer");
+		inf.setExtendedMetadata(AbcField.SONG_TRANSCRIBER, "Your Name Here");
+		for (int i = 0; i < 5; i++) {
+			inf.partInfoByIndex.put(i, new PartInfo());
+		}
+		
+		return inf;
 	}
 }

--- a/src/com/digero/common/abctomidi/AbcInfo.java
+++ b/src/com/digero/common/abctomidi/AbcInfo.java
@@ -25,6 +25,7 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 	private static class PartInfo {
 		private int number = 1;
 		private LotroInstrument instrument = LotroInstrument.DEFAULT_INSTRUMENT;
+		private boolean instrumentIsFromMadeFor = false;
 		private String name = null;
 		private String rawName = null;
 		private boolean nameIsFromExtendedInfo = false;
@@ -198,6 +199,13 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 		if (info == null)
 			return LotroInstrument.DEFAULT_INSTRUMENT;
 		return info.instrument;
+	}
+	
+	public boolean getPartInstrumentFromMadeFor(int trackIndex) {
+		AbcInfo.PartInfo info = partInfoByIndex.get(trackIndex);
+		if (info == null)
+			return false;
+		return info.instrumentIsFromMadeFor;
 	}
 
 	public int getPartCount() {
@@ -421,6 +429,15 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 			partInfoByIndex.put(trackIndex, info = new PartInfo());
 
 		info.instrument = partInstrument;
+	}
+	
+	void setPartInstrument(int trackIndex, LotroInstrument partInstrument, boolean madeFor) {
+		AbcInfo.PartInfo info = partInfoByIndex.get(trackIndex);
+		if (info == null)
+			partInfoByIndex.put(trackIndex, info = new PartInfo());
+
+		info.instrument = partInstrument;
+		info.instrumentIsFromMadeFor = madeFor;
 	}
 
 	void setPartName(int trackIndex, String partName, boolean fromExtendedInfo) {

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -939,8 +939,12 @@ public class AbcToMidi {
 						if (field == AbcField.PART_NAME) {
 							abcInfo.setPartName(trackNumber, value, true);
 							LotroInstrument instrument = LotroInstrument.findInstrumentName(value, null);
-							if (instrument != null)
+							if (!abcInfo.getPartInstrumentFromMadeFor(trackNumber) && instrument != null)
 								abcInfo.setPartInstrument(trackNumber, instrument);
+						} else if (field == AbcField.MADE_FOR) {
+							LotroInstrument instrument = LotroInstrument.findInstrumentName(value, null);
+							if (instrument != null)
+								abcInfo.setPartInstrument(trackNumber, instrument, true /*made for*/);
 						}
 					}
 					continue;

--- a/src/com/digero/common/abctomidi/AbcToMidi.java
+++ b/src/com/digero/common/abctomidi/AbcToMidi.java
@@ -938,6 +938,9 @@ public class AbcToMidi {
 						abcInfo.setExtendedMetadata(field, value);
 						if (field == AbcField.PART_NAME) {
 							abcInfo.setPartName(trackNumber, value, true);
+							LotroInstrument instrument = LotroInstrument.findInstrumentName(value, null);
+							if (instrument != null)
+								abcInfo.setPartInstrument(trackNumber, instrument);
 						}
 					}
 					continue;

--- a/src/com/digero/common/util/AbcFileTreeModel.java
+++ b/src/com/digero/common/util/AbcFileTreeModel.java
@@ -2,7 +2,7 @@ package com.digero.common.util;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
 
@@ -51,6 +51,26 @@ public class AbcFileTreeModel implements TreeModel {
 		}
 	}
 	
+	public void sort(SortType sort) {
+		for (AbcSongFileNode node : rootNode.children) {
+			node.sort(getComparator(sort));
+		}
+		
+		for (TreeModelListener l : listeners) {
+			l.treeStructureChanged(new TreeModelEvent(this, new TreePath(rootNode)));
+		}
+	}
+	
+	public void filter(String filterStr) {
+		for (AbcSongFileNode node : rootNode.children) {
+			rootNode.filter(filterStr);
+		}
+		
+		for (TreeModelListener l : listeners) {
+			l.treeStructureChanged(new TreeModelEvent(this, new TreePath(rootNode)));
+		}
+	}
+	
 	public void setDirectories(List<File> directories) {
 		rootNode.children.clear();
 		for (File file : directories) {
@@ -70,7 +90,7 @@ public class AbcFileTreeModel implements TreeModel {
 
 	@Override
 	public int getChildCount(Object parentObj) {
-		return ((AbcSongFileNode) parentObj).children.size();
+		return ((AbcSongFileNode) parentObj).filteredChildren.size();
 	}
 
 	@Override
@@ -102,31 +122,51 @@ public class AbcFileTreeModel implements TreeModel {
 		
 	}
 	
-	private Comparator<File> getComparator(SortType type) {
+	private Comparator<AbcSongFileNode> getComparator(SortType type) {
+		Comparator<AbcSongFileNode> folderFirstComparator = (f1, f2) -> {
+			if (f1.getFile().isDirectory() == f2.getFile().isDirectory()) {
+				return 0;
+			} else {
+				return f1.getFile().isDirectory() ? -1 : 1;
+			}
+		};
+		
+		Comparator<AbcSongFileNode> sortComparator;
+		
 		switch (type) {
 		case NAME_ASC:
-			return (f1, f2) -> f1.getName().compareToIgnoreCase(f2.getName());
+			sortComparator = (f1, f2) -> f1.getFile().getName().compareToIgnoreCase(f2.getFile().getName());
+			break;
 		case NAME_DESC:
-			return (f1, f2) -> f2.getName().compareToIgnoreCase(f1.getName());
+			sortComparator = (f1, f2) -> f2.getFile().getName().compareToIgnoreCase(f1.getFile().getName());
+			break;
 		case LAST_MODIFIED_ASC:
-			return (f1, f2) -> Long.compare(f1.lastModified(), f2.lastModified());
+			sortComparator = (f1, f2) -> Long.compare(f1.getFile().lastModified(), f2.getFile().lastModified());
+			break;
 		case LAST_MODIFIED_DESC:
-			return (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified());
+			sortComparator = (f1, f2) -> Long.compare(f2.getFile().lastModified(), f1.getFile().lastModified());
+			break;
 		case SIZE_ASC:
-			return (f1, f2) -> Long.compare(f1.length(), f2.length());
+			sortComparator = (f1, f2) -> Long.compare(f1.getFile().length(), f2.getFile().length());
+			break;
 		case SIZE_DESC:
-			return (f1, f2) -> Long.compare(f2.length(), f1.length());
+			sortComparator = (f1, f2) -> Long.compare(f2.getFile().length(), f1.getFile().length());
+			break;
 		default:
-			return (f1, f2) -> f1.getName().compareToIgnoreCase(f2.getName());
+			sortComparator = (f1, f2) -> f1.getFile().getName().compareToIgnoreCase(f2.getFile().getName());
+			break;
 		}
+		
+		return folderFirstComparator.thenComparing(sortComparator);
 	}
 	
 	public class AbcSongFileNode {
 		private final File theFile;
-		private ArrayList<AbcSongFileNode> children;
+		private ArrayList<AbcSongFileNode> children = new ArrayList<AbcSongFileNode>();
+		private ArrayList<AbcSongFileNode> filteredChildren = new ArrayList<AbcSongFileNode>();
 		
-		public void refresh(Comparator<File> sorter) {
-			children = new ArrayList<AbcSongFileNode>();
+		public void refresh(Comparator<AbcSongFileNode> sorter) {
+			children.clear();
 			if (!theFile.isDirectory() || !theFile.exists()) {
 				return;
 			}
@@ -137,43 +177,57 @@ public class AbcFileTreeModel implements TreeModel {
 				return;
 			}
 			
-			File[] files = Arrays.stream(childFiles).filter(File::isFile).toArray(File[]::new);
-			File[] folders = Arrays.stream(childFiles).filter(File::isDirectory).toArray(File[]::new);
-			
-			Arrays.sort(files, sorter);
-			Arrays.sort(folders, sorter);
-			
-			for (File folder: folders) {
-				AbcSongFileNode node = new AbcSongFileNode(folder);
-				node.refresh(sorter);
-				children.add(node);
-			}
-			
-			for (File file : files) {
+			for (File file : childFiles) {
 				AbcSongFileNode node = new AbcSongFileNode(file);
 				node.refresh(sorter);
 				children.add(node);
 			}
+			
+			children.sort(sorter);
+			
+		}
+		
+		public void sort(Comparator<AbcSongFileNode> sorter) {
+			for (AbcSongFileNode child : children) {
+				child.sort(sorter);
+			}
+			
+			children.sort(sorter);
+		}
+		
+		public boolean filter(String filterStr) {
+			boolean hasMatchedChild = false;
+			
+			filteredChildren.clear();
+			
+			for (AbcSongFileNode child : children)
+			{
+				if (child.filter(filterStr)) {
+					hasMatchedChild = true;
+					filteredChildren.add(child);
+				}
+			}
+			
+			return hasMatchedChild || theFile.getName().toLowerCase().contains(filterStr);
 		}
 		
 		public AbcSongFileNode(final File theFile) {
 			this.theFile = theFile;
-			this.children = new ArrayList<AbcSongFileNode>();
 		}
 		
 		public boolean isLeaf() {
-			return theFile.isFile() || children.isEmpty();
+			return theFile.isFile() || filteredChildren.isEmpty();
 		}
 		
 		public AbcSongFileNode getChildAt(int i) {
-			if (i < 0 || children == null || i >= children.size()) {
+			if (i < 0 || i >= filteredChildren.size()) {
 				return null;
 			}
-			return children.get(i);
+			return filteredChildren.get(i);
 		}
 		
 		public int getIndexOf(AbcSongFileNode node) {
-			return children.indexOf(node);
+			return filteredChildren.indexOf(node);
 		}
 
 	    public File getFile() {

--- a/src/com/digero/common/util/AbcFileTreeModel.java
+++ b/src/com/digero/common/util/AbcFileTreeModel.java
@@ -2,7 +2,6 @@ package com.digero.common.util;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
 
@@ -62,9 +61,7 @@ public class AbcFileTreeModel implements TreeModel {
 	}
 	
 	public void filter(String filterStr) {
-		for (AbcSongFileNode node : rootNode.children) {
-			rootNode.filter(filterStr);
-		}
+		rootNode.filter(filterStr);
 		
 		for (TreeModelListener l : listeners) {
 			l.treeStructureChanged(new TreeModelEvent(this, new TreePath(rootNode)));
@@ -184,7 +181,6 @@ public class AbcFileTreeModel implements TreeModel {
 			}
 			
 			children.sort(sorter);
-			
 		}
 		
 		public void sort(Comparator<AbcSongFileNode> sorter) {

--- a/src/com/digero/common/util/FileFilterDropListener.java
+++ b/src/com/digero/common/util/FileFilterDropListener.java
@@ -114,7 +114,7 @@ public class FileFilterDropListener implements DropTargetListener {
 				return null;
 			}
 
-			if (files.isEmpty() || !acceptMultiple && files.size() > 1)
+			if (files == null || files.isEmpty() || !acceptMultiple && files.size() > 1)
 				return null;
 
 			for (File file : files) {

--- a/src/com/digero/common/view/HintTextField.java
+++ b/src/com/digero/common/view/HintTextField.java
@@ -1,0 +1,42 @@
+package com.digero.common.view;
+
+import java.awt.Color;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.RenderingHints;
+
+import javax.swing.JTextField;
+
+public class HintTextField extends JTextField {
+	private static final long serialVersionUID = -2850639316389631548L;
+	public String hint;
+	
+	public HintTextField(String hint) {
+		super();
+		this.hint = hint;
+	}
+	
+	public HintTextField(String hint, int cols) {
+		super(cols);
+		this.hint = hint;
+	}
+	
+	@Override
+	public void paint(Graphics g) {
+		super.paint(g);
+		if (getText().isEmpty()) {
+			int h = getHeight();
+			((Graphics2D)g).setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+			Insets ins = getInsets();
+            FontMetrics fm = g.getFontMetrics();
+            int c0 = getBackground().getRGB();
+            int c1 = getForeground().getRGB();
+            int m = 0xfefefefe;
+            int c2 = ((c0 & m) >>> 1) + ((c1 & m) >>> 1);
+            g.setColor(new Color(c2, true));
+            g.drawString(hint, ins.left, h / 2 + fm.getAscent() / 2 - 2);
+		}
+	}
+}


### PR DESCRIPTION
- Added a search feature to the ABC browser, it will search as you type for song files which match (case insensitive)
- The ABC browser will keep folders expanded when you change the sort type or refresh files (or use search)
- The ABC playlist table will scroll to the end when new songs are added which would appear off screen
- You can now press tab to switch between the song view and the browser/playlist view
- Opening an ABC song through dragging or the file->open menu will switch to the song view if nothing's playing
- Opening a playlist will switch to the playlist view if nothing's playing
- Added a set export wizard feature to the playlist
  - Accessible through the Playlist menu, "Export Playlist as Set..."
  - Allows you to export the currently loaded playlist's songs into a new folder or zipped file
  - File renaming pattern lets you reorder the songs to match the playlist using the $SongIndex variable
  - Optionally export a CSV part sheet file (importable into Excel, Google Docs, etc.) which adds a row for each song:
    - The song filename
    - Optional columns for song fields such as composer, duration, etc.,
    - One or more columns containing either the part names or the instrument names of each song