### PR TITLE
Playlist sort and fixes

### DIFF
--- a/distribute/Changes since Maestro 2.5.0.txt
+++ b/distribute/Changes since Maestro 2.5.0.txt
@@ -48,6 +48,12 @@ Thanks to all who gave feedback of features and bugs plus suggestions.
 Maestro upgrades by Aifel of Laurelin, Elamond of Landroval and Karloman
 ================
 
+Version 4.1.5
+- Add ability to sort playlist based on columns, in right-click playlist header menu
+- Add a playlist menu toggle to auto-expand folders with matched songs when searching
+- Fix bug where the playlist "Refresh Browser" function wouldn't work until you searched
+- Fix bug where the set exporter wouldn't honor the option to not rename files
+
 Version 4.1.4
 - Invert how priorites of setups work.
 

--- a/src/com/digero/abcplayer/version.txt
+++ b/src/com/digero/abcplayer/version.txt
@@ -1,1 +1,1 @@
-version.AbcPlayer=4.1.4
+version.AbcPlayer=4.1.5

--- a/src/com/digero/abcplayer/view/AbcInfoTableModel.java
+++ b/src/com/digero/abcplayer/view/AbcInfoTableModel.java
@@ -2,6 +2,8 @@ package com.digero.abcplayer.view;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.swing.table.AbstractTableModel;
@@ -66,6 +68,64 @@ public class AbcInfoTableModel extends AbstractTableModel {
 	@Override
 	public int getRowCount() {
 		return data.size();
+	}
+	
+	public void sortBy(String columnName, boolean ascending) {
+		int colIdx = getColumnNames().indexOf(columnName);
+		if (colIdx == -1) {
+			return;
+		}
+		
+		Comparator<AbcInfo> comp = (AbcInfo row1, AbcInfo row2) -> {
+			Object val1 = getColumnValueForAbcInfo(row1, colIdx);
+			Object val2 = getColumnValueForAbcInfo(row2, colIdx);
+			
+			if (val1 == null && val2 == null) return 0;
+			else if (val1 == null) return ascending ? -1 : 1;
+			else if (val2 == null) return ascending ? 1 : -1;
+			
+			if (columnName.equals("Duration")) {
+				return compareDurations((String)val1, (String)val2, ascending);
+			}
+			
+			if (val1 instanceof String && val2 instanceof String) {
+				return ascending ?
+						((String)val1).compareToIgnoreCase((String)val2) :
+						((String)val2).compareToIgnoreCase((String)val1);
+			} else if (val1 instanceof Integer && val2 instanceof Integer) {
+				return ascending ?
+						((Integer)val1).compareTo((Integer)val2) :
+						((Integer)val2).compareTo((Integer)val1);
+			} else { // default to string
+				return ascending ?
+						val1.toString().compareToIgnoreCase(val2.toString()) :
+						val2.toString().compareToIgnoreCase(val1.toString());
+			}
+		};
+		
+		Collections.sort(data, comp);
+		
+		fireTableDataChanged();
+	}
+	
+	public static int compareDurations(String ds1, String ds2, boolean ascending) {
+		try {
+			String[] duration1 = ds1.split(":");
+			String[] duration2 = ds2.split(":");
+			
+			int min1 = Integer.parseInt(duration1[0]);
+			int sec1 = Integer.parseInt(duration1[1]);
+			
+			int min2 = Integer.parseInt(duration2[0]);
+			int sec2 = Integer.parseInt(duration2[1]);
+			
+			int totalSec1 = (min1 * 60) + sec1;
+			int totalSec2 = (min2 * 60) + sec2;
+			
+			return ascending ? Integer.compare(totalSec1, totalSec2) : Integer.compare(totalSec2, totalSec1);
+		} catch (Exception e) {
+			return ascending ? ds1.compareToIgnoreCase(ds2) : ds2.compareToIgnoreCase(ds1);
+		}
 	}
 	
 	public static String getNameOfColumn(int colIndex) {

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -729,7 +729,7 @@ public class AbcPlaylistPanel extends JPanel {
 			public void removeUpdate(DocumentEvent e) { update(e); }
 			
 			public void update(DocumentEvent e) {
-				abcFileTreeModel.filter(searchTextField.getText().toLowerCase());
+				abcFileTreeModel.filter(searchTextField.getText());
 				reExpandPaths();
 			}
 		});
@@ -925,6 +925,7 @@ public class AbcPlaylistPanel extends JPanel {
 		JMenuItem refreshMenuItem = playlistMenu.add(new JMenuItem("Refresh Browser"));
 		refreshMenuItem.addActionListener(e -> {
 			abcFileTreeModel.refresh(sortType);
+			abcFileTreeModel.filter(searchTextField.getText());
 			reExpandPaths();
 		});
 	}

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -164,6 +164,7 @@ public class AbcPlaylistPanel extends JPanel {
 	private JMenuItem saveMenuItem;
 	private JCheckBoxMenuItem autoplayMenuItem;
 	private JCheckBoxMenuItem playbackDelayMenuItem;
+	private JCheckBoxMenuItem expandSearchMenuItem;
 	private JMenuItem exportSetMenuItem;
 	
 	private JFileChooser openPlaylistChooser = null;
@@ -314,7 +315,7 @@ public class AbcPlaylistPanel extends JPanel {
 
 			@Override
 			public void treeExpanded(TreeExpansionEvent e) {
-				expandedAbcTrees.add(e.getPath());	
+				expandedAbcTrees.add(e.getPath());
 			}
 		});
 		JPopupMenu fileTreePopup = new JPopupMenu();
@@ -730,6 +731,9 @@ public class AbcPlaylistPanel extends JPanel {
 			
 			public void update(DocumentEvent e) {
 				abcFileTreeModel.filter(searchTextField.getText());
+				if (!searchTextField.getText().isEmpty() && expandSearchMenuItem.isSelected()) {
+					expandMatchedPaths();
+				}
 				reExpandPaths();
 			}
 		});
@@ -887,6 +891,11 @@ public class AbcPlaylistPanel extends JPanel {
 		playbackDelayMenuItem.addActionListener(e -> {
 			playlistPrefs.putBoolean("playbackDelay", playbackDelayMenuItem.isSelected());
 		});
+		expandSearchMenuItem = (JCheckBoxMenuItem) playlistMenu.add(new JCheckBoxMenuItem("Enable Auto-Expanding Searched Folders"));
+		expandSearchMenuItem.setSelected(playlistPrefs.getBoolean("autoExpandSearch", false));
+		expandSearchMenuItem.addActionListener(e -> {
+			playlistPrefs.putBoolean("autoExpandSearch", expandSearchMenuItem.isSelected());
+		});
 		playlistMenu.addSeparator();
 		JMenu sortBy = new JMenu("Sort browser by...");
 		playlistMenu.add(sortBy);
@@ -930,9 +939,35 @@ public class AbcPlaylistPanel extends JPanel {
 		});
 	}
 	
+	private void expandMatchedPaths() {
+		HashSet<TreePath> validExpandedTrees = new HashSet<TreePath>();
+		AbcSongFileNode root = (AbcSongFileNode)abcFileTreeModel.getRoot();
+		traverseAndExpand(validExpandedTrees, root, new TreePath(root));
+		expandedAbcTrees = validExpandedTrees;
+	}
+	
+	private void traverseAndExpand(HashSet<TreePath> newExpanded, AbcSongFileNode node, TreePath nodePath) {
+		if (!node.isLeaf()) {
+			boolean hasChildFolder = false;
+			for (int i = 0; i < node.getChildrenCount(); i++) {
+				AbcSongFileNode child = node.getChildAt(i);
+				TreePath childPath = nodePath.pathByAddingChild(child);
+				if (child.getChildrenCount() != 0) {
+					traverseAndExpand(newExpanded, child, childPath);
+					hasChildFolder = true;
+				}
+			}
+			
+			if (!hasChildFolder) {
+				newExpanded.add(nodePath);
+			}
+		}
+	}
+	
 	private void reExpandPaths() {
 		HashSet<TreePath> validExpandedTrees = new HashSet<TreePath>();
-		for (TreePath path : expandedAbcTrees) {
+		HashSet<TreePath> snapshot = new HashSet<>(expandedAbcTrees);
+		for (TreePath path : snapshot) {
 			Object[] nodes = path.getPath();
 			Object walk = abcFileTreeModel.getRoot();
 			boolean found = true;

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -10,6 +10,7 @@ import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -1003,8 +1004,13 @@ public class AbcPlaylistPanel extends JPanel {
 		playlistHeaderPopupMenu.add(sortMenu);
 		
 		for (String col : colNames) {
-			ascending.add(new JMenuItem(col));
-			descending.add(new JMenuItem(col));
+			JMenuItem asc = ascending.add(new JMenuItem(col));
+			JMenuItem desc = descending.add(new JMenuItem(col));
+			ActionListener listen = e -> {
+				tableModel.sortBy(col, e.getSource() == asc);
+			};
+			asc.addActionListener(listen);
+			desc.addActionListener(listen);
 		}
 	}
 	

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -610,6 +610,11 @@ public class AbcPlaylistPanel extends JPanel {
 		playlistHeaderPopupMenu.addSeparator();
 		playlistTable.getTableHeader().setComponentPopupMenu(playlistHeaderPopupMenu);
 		playlistTable.getTableHeader().setReorderingAllowed(false);
+		
+		initTableHeaderSort();
+		
+		playlistHeaderPopupMenu.addSeparator();
+		
 		initTableHeaderColumns();
 		
 		Preferences colSizes = playlistPrefs.node("colSizes");
@@ -985,6 +990,21 @@ public class AbcPlaylistPanel extends JPanel {
 			}
 			playlistHeaderPopupMenu.add(item);
 			columnEnablers[i] = item;
+		}
+	}
+	
+	private void initTableHeaderSort() {
+		List<String> colNames = tableModel.getColumnNames();
+		JMenu sortMenu = new JMenu("Sort Playlist By...");
+		JMenu ascending = new JMenu("Ascending");
+		JMenu descending = new JMenu("Descending");
+		sortMenu.add(ascending);
+		sortMenu.add(descending);
+		playlistHeaderPopupMenu.add(sortMenu);
+		
+		for (String col : colNames) {
+			ascending.add(new JMenuItem(col));
+			descending.add(new JMenuItem(col));
 		}
 	}
 	

--- a/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
+++ b/src/com/digero/abcplayer/view/PlaylistSetExportWizard.java
@@ -598,7 +598,10 @@ public class PlaylistSetExportWizard extends JDialog {
 			float progress = 10;
 			for (int i = 0; i < count; i++) {
 				AbcInfo inf = setData.get(i);
-				String newName = getFormattedName(inf, i);
+				String newName = inf.getSourceFiles().get(0).getName();
+				if (settings.renameAbcFiles) {
+					newName = getFormattedName(inf, i);
+				}
 				Path source = inf.getSourceFiles().get(0).toPath();
 				Path dest = copyToFolder.toPath().resolve(newName);
 				try {

--- a/src/com/digero/common/util/AbcFileTreeModel.java
+++ b/src/com/digero/common/util/AbcFileTreeModel.java
@@ -228,6 +228,10 @@ public class AbcFileTreeModel implements TreeModel {
 			return filteredChildren.get(i);
 		}
 		
+		public int getChildrenCount() {
+			return filteredChildren.size();
+		}
+		
 		public int getIndexOf(AbcSongFileNode node) {
 			return filteredChildren.indexOf(node);
 		}

--- a/src/com/digero/common/util/AbcFileTreeModel.java
+++ b/src/com/digero/common/util/AbcFileTreeModel.java
@@ -61,7 +61,7 @@ public class AbcFileTreeModel implements TreeModel {
 	}
 	
 	public void filter(String filterStr) {
-		rootNode.filter(filterStr);
+		rootNode.filter(filterStr.toLowerCase());
 		
 		for (TreeModelListener l : listeners) {
 			l.treeStructureChanged(new TreeModelEvent(this, new TreePath(rootNode)));

--- a/src/com/digero/maestro/version.txt
+++ b/src/com/digero/maestro/version.txt
@@ -1,1 +1,1 @@
-version.Maestro=4.1.4
+version.Maestro=4.1.5


### PR DESCRIPTION
- Add ability to sort playlist based on columns, in right-click playlist header menu
- Add a playlist menu toggle to auto-expand folders with matched songs when searching
- Fix bug where the playlist "Refresh Browser" function wouldn't work until you searched
- Fix bug where the set exporter wouldn't honor the option to not rename files