### PR TITLE
Don't discard and recreate trackpanels, drumpanels, histo/tempo panels when switching tracks

### DIFF
--- a/src/com/digero/maestro/view/DrumPanel.java
+++ b/src/com/digero/maestro/view/DrumPanel.java
@@ -505,8 +505,10 @@ public class DrumPanel extends JPanel implements IDiscardable, TableLayoutConsta
 		}
 	}
 
-	public void setAbcPart(AbcPart abcPart) {
-		this.abcPart = abcPart;
+	public void setAbcPart(AbcPart part) {
+		part.removeAbcListener(abcPartListener);
+		this.abcPart = part;
+		abcPart.addAbcListener(abcPartListener);
 		checkBox.setSelected(abcPart.isPercussionNoteEnabled(trackInfo.getTrackNumber(), drumId));
 		updateState();
 	}

--- a/src/com/digero/maestro/view/DrumPanel.java
+++ b/src/com/digero/maestro/view/DrumPanel.java
@@ -504,4 +504,10 @@ public class DrumPanel extends JPanel implements IDiscardable, TableLayoutConsta
 			return abcPart.getAbcSong().getFirstBarTick();
 		}
 	}
+
+	public void setAbcPart(AbcPart abcPart) {
+		this.abcPart = abcPart;
+		checkBox.setSelected(abcPart.isPercussionNoteEnabled(trackInfo.getTrackNumber(), drumId));
+		updateState();
+	}
 }

--- a/src/com/digero/maestro/view/PartPanel.java
+++ b/src/com/digero/maestro/view/PartPanel.java
@@ -99,7 +99,6 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 	// Note graphs
 	HistogramPanel histogramPanel;
 	TempoPanel tempoPanel;
-	
 	HashMap<Integer, TrackPanel> trackPanels = new HashMap<Integer, TrackPanel>();
 	
 	private ControlLayout controlLayout;
@@ -317,10 +316,8 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 		JScrollBar noteGraphBar = noteGraphScrollPane.getVerticalScrollBar();		
 		noteGraphBar.setUnitIncrement(TrackPanel.calculateTrackDims().rowHeight / 2);
 
-		
 		splitPanel.add(controlPanel, "0, 0");
 		splitPanel.add(noteGraphScrollPane, "1, 0, f, f");
-		
 		
 		messageLabel = new JLabel();
 		messageLabel.setHorizontalAlignment(SwingConstants.CENTER);
@@ -474,8 +471,12 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 		numberSpinnerModel.setStepSize(partAutoNumberer.getIncrement());
 	}
 	
-	public void changeAbcSong() {
-		
+	public void closeAbcSong() {
+		clearTrackListPanel(true);
+		histogramPanel = null;
+		tempoPanel = null;
+		trackPanels.clear();
+		abcPart = null;
 	}
 
 	public void setAbcPart(AbcPart abcPart, boolean force) {
@@ -580,7 +581,7 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 				@Override
 				public boolean isVerticalZoomForbidden() {
 					return true;
-				}				
+				}
 			}			
 			Dummy dummy1 = new Dummy();
 			dummy1.setPreferredSize(new Dimension(100, scrollbarHeight * 2));

--- a/src/com/digero/maestro/view/PartPanel.java
+++ b/src/com/digero/maestro/view/PartPanel.java
@@ -17,6 +17,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.text.ParseException;
+import java.util.HashMap;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -94,6 +95,12 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 	
 	private PatchedJScrollPane noteGraphScrollPane;
 	private JPanel noteGraphPanel;
+	
+	// Note graphs
+	HistogramPanel histogramPanel;
+	TempoPanel tempoPanel;
+	
+	HashMap<Integer, TrackPanel> trackPanels = new HashMap<Integer, TrackPanel>();
 	
 	private ControlLayout controlLayout;
 	private GraphLayout graphLayout;
@@ -242,15 +249,11 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 		zoomPanel.add(followCheckBox);
 		partSettingsPanel.add(zoomPanel);
 
-//		boolean dbg = false;
-//		dbg = true;
-//		splitPanel = new JPanel(new MigLayout((dbg? "debug, " : "") + "wrap 2, gap 0, ins 0, novisualpadding, filly", "[]0[grow]"));
 		splitPanel = new JPanel(new TableLayout(new double[] { PREFERRED, FILL }, //
 				new double[] { FILL }));
 		splitPanel.setBorder(BorderFactory.createEmptyBorder());
 		splitPanel.setBackground(ColorTable.PANEL_BACKGROUND_DISABLED.get());
 		
-		//controlPanel = new JPanel(new MigLayout((dbg? "debug, " : "") + "wrap 1, gap 0, novisualpadding, ins 0"));
 		noteGraphPanel = new JPanel() {
 			@Override
 			public Dimension getPreferredSize() {
@@ -316,12 +319,7 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 
 		
 		splitPanel.add(controlPanel, "0, 0");
-		splitPanel.add(noteGraphScrollPane, "1, 0, f, f");//noteGraphScrollPane
-		
-//		splitPanel.add(controlScrollPane, "top");
-//		splitPanel.add(noteGraphScrollPane, "top");
-		
-//		horizInnerScrollPane.add()
+		splitPanel.add(noteGraphScrollPane, "1, 0, f, f");
 		
 		
 		messageLabel = new JLabel();
@@ -338,9 +336,6 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 		noteContent.setTabSize(4);
 
 		add(partSettingsPanel, "0, 0");
-//		add(partSettingsPanel, "0, 0");
-//		add(zoomSettingsPanel, "0, 1");
-//		add(dataPanel, "0, 0");
 		add(messageLabel, "0, 2, C, C");
 		add(splitPanel, "0, 2");
 		
@@ -478,6 +473,10 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 	public void settingsChanged() {
 		numberSpinnerModel.setStepSize(partAutoNumberer.getIncrement());
 	}
+	
+	public void changeAbcSong() {
+		
+	}
 
 	public void setAbcPart(AbcPart abcPart, boolean force) {
 		messageLabel.setVisible(false);
@@ -506,7 +505,7 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 			nameTextField.setText("");
 			instrumentComboBox.setSelectedItem(LotroInstrument.DEFAULT_INSTRUMENT);
 
-			clearTrackListPanel();
+			clearTrackListPanel(true);
 		} else {
 			numberSpinner.setEnabled(true);
 			nameTextField.setEnabled(true);
@@ -519,12 +518,14 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 			nameTextField.setText(abcPart.getTitle());
 			instrumentComboBox.setSelectedItem(abcPart.getInstrument());
 
-			clearTrackListPanel();
+			clearTrackListPanel(false);
 
 			// Add the tempo panel if this song contains tempo changes
 			if (abcPart.getSequenceInfo().hasTempoChanges() || abcPart.getAbcSong().tuneBarsModified != null) {
-				TempoPanel tempoPanel = new TempoPanel(abcPart.getSequenceInfo(), sequencer, abcSequencer,
-						abcPart.getAbcSong());
+				if (tempoPanel == null) {
+					tempoPanel = new TempoPanel(abcPart.getSequenceInfo(), sequencer, abcSequencer,
+							abcPart.getAbcSong());
+				}
 				tempoPanel.setAbcPreviewMode(isAbcPreviewMode);
 				tempoPanel.revalidate();
 				controlPanel.add(tempoPanel,"x");
@@ -532,8 +533,10 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 			}
 			
 			// Add the histogram panel
-			HistogramPanel histogramPanel = new HistogramPanel(abcPart.getSequenceInfo(), sequencer, abcSequencer,
+			if (histogramPanel == null) {
+				histogramPanel = new HistogramPanel(abcPart.getSequenceInfo(), sequencer, abcSequencer,
 						abcPart.getAbcSong());
+			}
 			histogramPanel.setAbcPreviewMode(isAbcPreviewMode, showMaxPolyphony);
 			histogramPanel.revalidate();
 			
@@ -545,19 +548,14 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 			for (TrackInfo track : abcPart.getSequenceInfo().getTrackList()) {
 				int trackNumber = track.getTrackNumber();
 				if (track.hasEvents()) {
-					
-					TrackPanel trackPanel = new TrackPanel(track, sequencer, abcPart, abcSequencer, controlLayout);
+					if (!trackPanels.containsKey(trackNumber)) {
+						trackPanels.put(trackNumber, new TrackPanel(track, sequencer, abcPart, abcSequencer, controlLayout));
+					}
+					TrackPanel trackPanel = trackPanels.get(trackNumber);
+					trackPanel.setAbcPart(abcPart);
 					trackPanel.setAbcPreviewMode(isAbcPreviewMode);
 					controlPanel.add(trackPanel,"x");
 					noteGraphPanel.add(trackPanel.getNoteGraph(),"x");
-					
-					
-//					if (trackPanel.hasDrumPanels()) {
-//						ArrayList<DrumPanel> drums = trackPanel.getDrumPanels();
-//						for (DrumPanel dp : drums) {
-//							noteGraphPanel.add(dp.getNoteGraph(), "growx");
-//						}
-//					}
 
 					if (MUTE_DISABLED_TRACKS)
 						sequencer.setTrackMute(trackNumber, !abcPart.isTrackEnabled(trackNumber));
@@ -639,27 +637,21 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 		messageLabel.setVisible(true);
 	}
 
-	private void clearTrackListPanel() {
-		for (Component child : controlPanel.getComponents()) {
-			if (child instanceof IDiscardable) {
-				((IDiscardable) child).discard();
+	private void clearTrackListPanel(boolean discard) {
+		if (discard) {
+			for (Component child : controlPanel.getComponents()) {
+				if (child instanceof IDiscardable) {
+					((IDiscardable) child).discard();
+				}
 			}
-		}
-		for (Component child : noteGraphPanel.getComponents()) {
-			if (child instanceof IDiscardable) {
-				((IDiscardable) child).discard();
+			for (Component child : noteGraphPanel.getComponents()) {
+				if (child instanceof IDiscardable) {
+					((IDiscardable) child).discard();
+				}
 			}
 		}
 		controlPanel.removeAll();
 		noteGraphPanel.removeAll();
-	}
-
-	@Deprecated
-	private void setSequencer(NoteFilterSequencerWrapper sequencer) {
-		AbcPart abcPartTmp = this.abcPart;
-		setAbcPart(null, false);
-		this.sequencer = sequencer;
-		setAbcPart(abcPartTmp, false);
 	}
 
 	public void commitAllFields() {
@@ -671,10 +663,8 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 	}
 
 	public void updateZoom() {
-		
 		graphLayout.setZoomHorizontal(hZoom);
-		controlLayout.setZoomVertical(vZoom);		
-		
+		controlLayout.setZoomVertical(vZoom);
 	}
 
 	private void repaintAfterZoom() {
@@ -688,16 +678,8 @@ public class PartPanel extends JPanel implements ICompileConstants, TableLayoutC
 	
 	public void unZoom() {
 		// Called from ProjectFrame when song closes
-		
-//		hZoom = 1.0f;
-//		vZoom = 1.0f;
-//		
-//		graphLayout.setZoomHorizontal(hZoom);
-//		controlLayout.setZoomVertical(vZoom);
-		
 		hZoomSlider.setValue(0);
 		vZoomSlider.setValue(0);
-		
 		repaintAfterZoom();
 	}
 

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2066,6 +2066,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		partPanel.setTextnote("");
 		partPanel.textnoteVisible(false);
 		partPanel.unZoom();
+		partPanel.closeAbcSong();
 		
 		partEditor.setVisible(false);
 

--- a/src/com/digero/maestro/view/TrackPanel.java
+++ b/src/com/digero/maestro/view/TrackPanel.java
@@ -137,7 +137,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 	private AbcPart abcPart;
 
 	private JPanel gutter;
-	private JCheckBox checkBox;
+	private JCheckBox enableTrackCheckBox;
 	private TableLayoutConstraints checkBoxLayout_ControlsHidden;
 	private TableLayoutConstraints checkBoxLayout_ControlsVisible;
 	private TableLayoutConstraints checkBoxLayout_ControlsAndPriorityVisible;
@@ -153,16 +153,11 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 	private TrackNoteGraph noteGraph;
 	private ArrayList<DrumPanel> drumlinePanels;
 
-	public ArrayList<DrumPanel> getDrumPanels() {
-		return drumlinePanels;
-	}
-
 	private Listener<AbcPartEvent> abcListener;
 	private Listener<AbcSongEvent> songListener;
 	private Listener<SequencerEvent> seqListener;
 
-	private boolean showDrumPanels;
-	private boolean wasDrumPart;
+	private boolean showDrumPanels = false;
 	private boolean isAbcPreviewMode = false;
 
 	public TrackDimensions dims = new TrackDimensions(TITLE_WIDTH_DEFAULT, PRIORITY_WIDTH_DEFAULT,
@@ -198,7 +193,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		gutter = new JPanel((LayoutManager) null);
 		gutter.setOpaque(false);
 
-		checkBox = new JCheckBox() {
+		enableTrackCheckBox = new JCheckBox() {
 			@Override
 			public Dimension getPreferredSize() {
 				// This makes the title appear centered in the TrackPanel
@@ -211,13 +206,12 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				return getPreferredSize();
 			}
 		};
-		checkBox.setOpaque(false);
-//		checkBox.setFocusable(false);
-		checkBox.setSelected(abcPart.isTrackEnabled(trackInfo.getTrackNumber()));
+		enableTrackCheckBox.setOpaque(false);
+		enableTrackCheckBox.setSelected(abcPart.isTrackEnabled(trackInfo.getTrackNumber()));
 
-		checkBox.addActionListener(e -> {
+		enableTrackCheckBox.addActionListener(e -> {
 			int track = trackInfo.getTrackNumber();
-			boolean enabled = checkBox.isSelected();
+			boolean enabled = enableTrackCheckBox.isSelected();
 			abcPart.setTrackEnabled(track, enabled);
 			if (MUTE_DISABLED_TRACKS)
 				seq.setTrackMute(track, !enabled);
@@ -421,7 +415,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		*/
 		
 		add(gutter, GUTTER_COLUMN + ", 0, " + GUTTER_COLUMN + ", 1, f, f");
-		add(checkBox, checkBoxLayout_ControlsHidden);
+		add(enableTrackCheckBox, checkBoxLayout_ControlsHidden);
 		add(priorityBox, PRIORITY_COLUMN + ", 0, f, c");
 		add(controlPanel, CONTROL_COLUMN + ", 0, f, c");
 		
@@ -470,15 +464,20 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 
 		addPropertyChangeListener("enabled", evt -> updateState());
 
-		updateState(true);
+		updateState();
 	}
 	
 	public void setAbcPart(AbcPart part) {
 		abcPart.removeAbcListener(abcListener);
 		this.abcPart = part;
 		abcPart.addAbcListener(abcListener);
-		checkBox.setSelected(abcPart.isTrackEnabled(trackInfo.getTrackNumber()));
-		updateColors();
+//		showDrumPanels = abcPart.isTrackEnabled(trackInfo.getTrackNumber()) && !abcPart.isChromatic(trackInfo.getTrackNumber());
+		if (drumlinePanels != null && !drumlinePanels.isEmpty()) {
+			for (DrumPanel panel : drumlinePanels) {
+				panel.setAbcPart(abcPart);
+			}
+		}
+		updateState();
 	}
 	
 	@Override
@@ -538,6 +537,10 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 	}
 
 	private void initDrumMenuBar() {
+		if (drumControlBar != null) {
+			return;
+		}
+		
 		// Match colors of the parts panel for selected items
 		// Restore defaults after these components are created
 		Color bg = (Color)UIManager.get("MenuBar.selectionBackground");
@@ -735,7 +738,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		String title = trackInfo.getTrackNumber() + ". " + trackInfo.getName();
 		String instr = trackInfo.getInstrumentNames();
 
-		checkBox.setToolTipText("<html><b>" + title + "</b><br>" + instr + badString + "</html>");
+		enableTrackCheckBox.setToolTipText("<html><b>" + title + "</b><br>" + instr + badString + "</html>");
 
 		int titleWidth = dims.titleWidth;
 		if (!trackVolumeBar.isVisible()) {
@@ -744,9 +747,9 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 			titleWidth += dims.priorityWidth;
 		}
 
-		title = Util.ellipsis(title, titleWidth - ELLIPSIS_OFFSET, checkBox.getFont().deriveFont(Font.BOLD));
-		instr = Util.ellipsis(instr, titleWidth - ELLIPSIS_OFFSET, checkBox.getFont());
-		checkBox.setText("<html><b>" + title + "</b><br>" + instr + "</html>");
+		title = Util.ellipsis(title, titleWidth - ELLIPSIS_OFFSET, enableTrackCheckBox.getFont().deriveFont(Font.BOLD));
+		instr = Util.ellipsis(instr, titleWidth - ELLIPSIS_OFFSET, enableTrackCheckBox.getFont());
+		enableTrackCheckBox.setText("<html><b>" + title + "</b><br>" + instr + "</html>");
 
 	}
 
@@ -840,7 +843,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		} else if (!trackActive) {
 			noteGraph.setNoteColor(ColorTable.NOTE_OFF);
 			noteGraph.setBadNoteColor(ColorTable.NOTE_BAD_OFF);
-		} else // disabled (lighter colored) notes for playing tracks not in the current part
+		} else // disabled (lighter colored) notes for playing tracks not in the current par
 		{
 			boolean pseudoOff = !abcPreviewMode && (abcPart.isPercussionPart() != trackInfo.isDrumTrack());
 			noteGraph.setNoteColor(pseudoOff ? ColorTable.NOTE_OFF : ColorTable.NOTE_DISABLED);
@@ -848,27 +851,41 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		}
 
 		if (trackEnabled) {
-			checkBox.setForeground(ColorTable.PANEL_TEXT_ENABLED.get());
+			enableTrackCheckBox.setForeground(ColorTable.PANEL_TEXT_ENABLED.get());
 		} else {
 			boolean inputEnabled = abcPart.isPercussionPart() == trackInfo.isDrumTrack();
-			checkBox.setForeground(
+			enableTrackCheckBox.setForeground(
 					inputEnabled ? ColorTable.PANEL_TEXT_DISABLED.get() : ColorTable.PANEL_TEXT_OFF.get());
 		}
 
 		noteGraph.setOctaveLinesVisible(!trackInfo.isDrumTrack()
 				&& !(abcPart.getInstrument().isPercussion && abcPart.isTrackEnabled(trackInfo.getTrackNumber())));
 	}
-
-	private void updateState() {
-		updateState(false);
+	
+	private void initDrumPanels() {
+		initDrumMenuBar();
+		
+		if (drumlinePanels != null && !drumlinePanels.isEmpty()) {
+			return;
+		}
+		
+		drumlinePanels = new ArrayList<DrumPanel>();
+		for (int noteId : trackInfo.getNotesInUse()) {
+			DrumPanel drumlinePanel = new DrumPanel(trackInfo, seq, abcPart, noteId, abcSequencer, trackVolumeBar);
+			drumlinePanel.setAbcPreviewMode(isAbcPreviewMode);
+			drumlinePanels.add(drumlinePanel);
+		}
+		
+		// this array ends up being in reverse order from what is displayed, since we add the top row each time
+//		Collections.reverse(drumlinePanels);
 	}
 
-	private void updateState(boolean initDrumPanels) {
+	private void updateState() {
 		updateColors();
 
 		boolean trackEnabled = abcPart.isTrackEnabled(trackInfo.getTrackNumber());
 		boolean priorityEnabled = isPriorityEnabled();
-		checkBox.setSelected(trackEnabled);
+		enableTrackCheckBox.setSelected(trackEnabled);
 
 		// Update the visibility of controls
 		trackVolumeBar.setVisible(trackEnabled);
@@ -892,8 +909,8 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				? ((priorityEnabled || fxBox.isVisible()) ? checkBoxLayout_ControlsAndPriorityVisible : checkBoxLayout_ControlsVisible)
 				: checkBoxLayout_ControlsHidden;
 
-		if (layout.getConstraints(checkBox) != newCheckBoxLayout) {
-			layout.setConstraints(checkBox, newCheckBoxLayout);
+		if (layout.getConstraints(enableTrackCheckBox) != newCheckBoxLayout) {
+			layout.setConstraints(enableTrackCheckBox, newCheckBoxLayout);
 			updateTitleText();
 		}
 
@@ -907,67 +924,81 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		} else {
 			noteGraph.setDeltaVolume(abcPart.getTrackVolumeAdjust(trackInfo.getTrackNumber()));
 		}
-
-		boolean showDrumPanelsNew = !abcPart.isChromatic(trackInfo.getTrackNumber()) && trackEnabled;
-
-		if (initDrumPanels || showDrumPanels != showDrumPanelsNew || wasDrumPart != abcPart.isPercussionPart() || abcPart.getInstrument() == LotroInstrument.STUDENT_FIDDLE) {
-			if (showDrumPanels != showDrumPanelsNew) {
-				showDrumPanels = showDrumPanelsNew;
-			}
-			wasDrumPart = abcPart.isPercussionPart();
-
-			for (int i = getComponentCount() - 1; i >= 0; --i) {
-				Component child = getComponent(i);
-				if (child instanceof DrumPanel) {
-					((DrumPanel) child).discard();
-					remove(i);
-				}
-			}
-			
-			noteGraphPanel.removeAll();
-			noteGraph.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, ColorTable.PANEL_BORDER.get()));
-			noteGraphPanel.add(noteGraph, "grow");
-
-			drumlinePanels = new ArrayList<DrumPanel>();
-			if (drumControlBar != null) {
-				remove(drumControlBar);
-			}
-			
+		
+		boolean showDrumPanelsPrev = showDrumPanels;
+		showDrumPanels = !abcPart.isChromatic(trackInfo.getTrackNumber()) && trackEnabled;
+		
+//		System.out.println("show drum panels for track " + trackInfo.getTrackNumber() + ": " + showDrumPanels + "   (prev: " + showDrumPanelsPrev);
+		
+//		System.out.println("Does this even hit when we switch tracks? " + showDrumPanels);
+		
+//		boolean showDrumPanelsNew = !abcPart.isChromatic(trackInfo.getTrackNumber()) && trackEnabled;
+		
+		if (showDrumPanels != showDrumPanelsPrev) {
 			if (showDrumPanels) {
-				if (drumControlBar == null)
-					initDrumMenuBar();
+				System.out.println("Enabling drum panels on a track");
+				initDrumMenuBar();
+				
+				initDrumPanels();
 
 				add(drumControlBar, TITLE_COLUMN + ", 1," + (CONTROL_COLUMN -1) + ", 1");
 				
 				int row = LAYOUT_ROWS.length;
-				for (int noteId : trackInfo.getNotesInUse()) {
-					DrumPanel drumlinePanel = new DrumPanel(trackInfo, seq, abcPart, noteId, abcSequencer, trackVolumeBar);
+				
+				for (DrumPanel drumlinePanel : drumlinePanels) {
 					drumlinePanel.setAbcPreviewMode(isAbcPreviewMode);
 					if (row <= layout.getNumRow())
 						layout.insertRow(row, PREFERRED);
 					add(drumlinePanel, "0, " + row + ", " + NOTE_COLUMN + ", " + row);
-					if (drumlinePanels == null)
-						drumlinePanels = new ArrayList<>();
-					drumlinePanels.add(drumlinePanel);
 				}
 				
+//				for (int noteId : trackInfo.getNotesInUse()) {
+//					DrumPanel drumlinePanel = new DrumPanel(trackInfo, seq, abcPart, noteId, abcSequencer, trackVolumeBar);
+//					drumlinePanel.setAbcPreviewMode(isAbcPreviewMode);
+//					if (row <= layout.getNumRow())
+//						layout.insertRow(row, PREFERRED);
+//					add(drumlinePanel, "0, " + row + ", " + NOTE_COLUMN + ", " + row);
+//					if (drumlinePanels == null)
+//						drumlinePanels = new ArrayList<>();
+//					drumlinePanels.add(drumlinePanel);
+//				}
+				
 				// this array ends up being in reverse order from what is displayed, since we add the top row each time
-				Collections.reverse(drumlinePanels);
+//				Collections.reverse(drumlinePanels);
 				
 				// Rebuild note graph panel
 				noteGraph.setBorder(BorderFactory.createEmptyBorder());
 
 				DrumPanel last = null;
-				for (DrumPanel drumlinePanel : drumlinePanels) {
+				for (int i = drumlinePanels.size() - 1; i >= 0; i--) {
+					DrumPanel drumlinePanel = drumlinePanels.get(i);
 					noteGraphPanel.add(drumlinePanel.getNoteGraph(), "grow,shrink 0");
 					last = drumlinePanel;
 				}
 				last.getNoteGraph().setBorder(BorderFactory.createCompoundBorder(
 						BorderFactory.createMatteBorder(0, 0, 1, 0, ColorTable.PANEL_BORDER.get()),
 						BorderFactory.createMatteBorder(1, 0, 0, 0, ColorTable.OCTAVE_LINE.get())));
-			} else if (abcPart.isTrackEnabled(trackInfo.getTrackNumber()) && abcPart.getInstrument() == LotroInstrument.STUDENT_FIDDLE) {
-				//int controlHeight = getPreferredSize().height;
-				//noteGraph.setPreferredSize(new Dimension(noteGraph.getPreferredSize().width, controlHeight));
+				
+				drumMapMenu.setVisible(showDrumPanels && abcPart.isDrumPart());
+			}
+			else { // Don't show drum panels
+				System.out.println("Disabling drum panels on a track");
+				for (int i = getComponentCount() - 1; i >= 0; --i) {
+					Component child = getComponent(i);
+					if (child instanceof DrumPanel) {
+//						((DrumPanel) child).discard();
+						remove(i);
+					}
+				}
+				
+				noteGraphPanel.removeAll();
+				noteGraph.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, ColorTable.PANEL_BORDER.get()));
+				noteGraphPanel.add(noteGraph, "grow");
+				
+//				drumlinePanels = new ArrayList<DrumPanel>();
+				if (drumControlBar != null) {
+					remove(drumControlBar);
+				}
 			}
 
 			updateTitleText();
@@ -975,14 +1006,6 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 			revalidate();
 			noteGraphPanel.revalidate();
 		}
-		
-		if (showDrumPanels) {
-			drumMapMenu.setVisible(abcPart.isDrumPart());
-		}
-	}
-	
-	public boolean hasDrumPanels() {
-		return drumlinePanels != null && !drumlinePanels.isEmpty();
 	}
 
 	private boolean saveDrumMapping() {

--- a/src/com/digero/maestro/view/TrackPanel.java
+++ b/src/com/digero/maestro/view/TrackPanel.java
@@ -928,12 +928,6 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		boolean showDrumPanelsPrev = showDrumPanels;
 		showDrumPanels = !abcPart.isChromatic(trackInfo.getTrackNumber()) && trackEnabled;
 		
-//		System.out.println("show drum panels for track " + trackInfo.getTrackNumber() + ": " + showDrumPanels + "   (prev: " + showDrumPanelsPrev);
-		
-//		System.out.println("Does this even hit when we switch tracks? " + showDrumPanels);
-		
-//		boolean showDrumPanelsNew = !abcPart.isChromatic(trackInfo.getTrackNumber()) && trackEnabled;
-		
 		if (showDrumPanels != showDrumPanelsPrev) {
 			if (showDrumPanels) {
 				System.out.println("Enabling drum panels on a track");
@@ -951,20 +945,6 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 						layout.insertRow(row, PREFERRED);
 					add(drumlinePanel, "0, " + row + ", " + NOTE_COLUMN + ", " + row);
 				}
-				
-//				for (int noteId : trackInfo.getNotesInUse()) {
-//					DrumPanel drumlinePanel = new DrumPanel(trackInfo, seq, abcPart, noteId, abcSequencer, trackVolumeBar);
-//					drumlinePanel.setAbcPreviewMode(isAbcPreviewMode);
-//					if (row <= layout.getNumRow())
-//						layout.insertRow(row, PREFERRED);
-//					add(drumlinePanel, "0, " + row + ", " + NOTE_COLUMN + ", " + row);
-//					if (drumlinePanels == null)
-//						drumlinePanels = new ArrayList<>();
-//					drumlinePanels.add(drumlinePanel);
-//				}
-				
-				// this array ends up being in reverse order from what is displayed, since we add the top row each time
-//				Collections.reverse(drumlinePanels);
 				
 				// Rebuild note graph panel
 				noteGraph.setBorder(BorderFactory.createEmptyBorder());
@@ -986,7 +966,6 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				for (int i = getComponentCount() - 1; i >= 0; --i) {
 					Component child = getComponent(i);
 					if (child instanceof DrumPanel) {
-//						((DrumPanel) child).discard();
 						remove(i);
 					}
 				}
@@ -994,8 +973,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 				noteGraphPanel.removeAll();
 				noteGraph.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, ColorTable.PANEL_BORDER.get()));
 				noteGraphPanel.add(noteGraph, "grow");
-				
-//				drumlinePanels = new ArrayList<DrumPanel>();
+
 				if (drumControlBar != null) {
 					remove(drumControlBar);
 				}

--- a/src/com/digero/maestro/view/TrackPanel.java
+++ b/src/com/digero/maestro/view/TrackPanel.java
@@ -134,7 +134,7 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 	private final TrackInfo trackInfo;
 	private final NoteFilterSequencerWrapper seq;
 	private final SequencerWrapper abcSequencer;
-	private final AbcPart abcPart;
+	private AbcPart abcPart;
 
 	private JPanel gutter;
 	private JCheckBox checkBox;
@@ -471,6 +471,14 @@ public class TrackPanel extends JPanel implements IDiscardable, TableLayoutConst
 		addPropertyChangeListener("enabled", evt -> updateState());
 
 		updateState(true);
+	}
+	
+	public void setAbcPart(AbcPart part) {
+		abcPart.removeAbcListener(abcListener);
+		this.abcPart = part;
+		abcPart.addAbcListener(abcListener);
+		checkBox.setSelected(abcPart.isTrackEnabled(trackInfo.getTrackNumber()));
+		updateColors();
 	}
 	
 	@Override


### PR DESCRIPTION
This change keeps the panels persistent when switching tracks, and instead updates each panel with the currently selected ABC part so that they can update their rendering when the part switches.

The panels are reset when the song is closed.

Kind of experimental change and things may break, this should probably go into a beta.