### PR TITLE
Corrupt abc popup option

### DIFF
--- a/distribute/readme.txt
+++ b/distribute/readme.txt
@@ -50,6 +50,8 @@ Version 4.5.5
 - Auto-exporter is now threaded, expect a speed-up of 3 to 12 times.
 - A bit better handling of multi-stage initial silence.
 - Make play-head sync with count-in (when playback in progress).
+- Add option in AbcPlayer "More Options" menu to disable ABC potential corruption popup messages
+- The potential corrupt ABC message can be viewed by hovering over the ABC title, or the playlist lines
 
 Version 4.4.6
 - Removed warnings for bad Jaunty notes.

--- a/src/com/digero/abcplayer/AbcPlayer.java
+++ b/src/com/digero/abcplayer/AbcPlayer.java
@@ -688,17 +688,21 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 			genreLabel.setVisible(false);
 			return;
 		}
-		
+
+		String issue = abcInfo.getIssue();
+		if (!issue.isEmpty()) {
+			issue = "\nPotential corrupted ABC from " + abcInfo.getAbcCreator() + ":\n" + issue;
+		}
 		String title = abcInfo.getTitle();
 		String artist = abcInfo.getComposer_MaybeNull();
 		String transcriber = abcInfo.getTranscriber_MaybeNull();
 
 		titleLabel.setText(title);
-		titleLabel.setToolTipText("Song Title: " + title);
+		titleLabel.setToolTipText("Song Title: " + title + issue);
 
 		if (artist != null) {
 			composerLabel.setText(artist);
-			composerLabel.setToolTipText("Artist: " + artist);
+			composerLabel.setToolTipText("Artist: " + artist + issue);
 			composerLabel.setVisible(true);
 		} else {
 			composerLabel.setVisible(false);
@@ -706,7 +710,7 @@ public class AbcPlayer extends JFrame implements TableLayoutConstants, MidiConst
 
 		if (transcriber != null) {
 			transcriberLabel.setText(transcriber);
-			transcriberLabel.setToolTipText("Transcriber: " + transcriber);
+			transcriberLabel.setToolTipText("Transcriber: " + transcriber + issue);
 			transcriberLabel.setVisible(true);
 		} else {
 			transcriberLabel.setVisible(false);

--- a/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
+++ b/src/com/digero/abcplayer/view/AbcPlayerSettingsDialog.java
@@ -4,14 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.util.prefs.Preferences;
 
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
+import javax.swing.*;
 
 import com.digero.common.util.Themer;
 
@@ -100,6 +93,12 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 			fontBox.addItem(Integer.toString(i));
 		}
 		fontBox.setSelectedItem(Integer.toString(prefs.getInt("fontSize", Themer.DEFAULT_FONT_SIZE)));
+
+		final JCheckBox flawedMaestroCheckbox = new JCheckBox("Enable popup warning for ABCs exported from flawed Maestro versions");
+		flawedMaestroCheckbox.setSelected(prefs.getBoolean("flawedMaestroPopup", true));
+		flawedMaestroCheckbox.addActionListener(e-> {
+			prefs.putBoolean("flawedMaestroPopup", flawedMaestroCheckbox.isSelected());
+		});
 		
 		TableLayout layout = new TableLayout();
 		layout.insertColumn(0, FILL);
@@ -121,6 +120,9 @@ public class AbcPlayerSettingsDialog extends JDialog implements TableLayoutConst
 		
 		layout.insertRow(++row, PREFERRED);
 		panel.add(fontBox, "0, " + row);
+
+		layout.insertRow(++row, PREFERRED);
+		panel.add(flawedMaestroCheckbox, "0, " + row);
 		
 		return panel;
 	}

--- a/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
+++ b/src/com/digero/abcplayer/view/AbcPlaylistPanel.java
@@ -456,6 +456,10 @@ public class AbcPlaylistPanel extends JPanel {
 						}
 						txt = txt + inf.getPartFullName(i + 1);
 					}
+					String issue = inf.getIssue();
+					if (!issue.isEmpty()) {
+						txt = txt + "\nPotential corrupted ABC from " + inf.getAbcCreator() + ":\n" + issue;
+					}
 				}
 				return txt;
 			}

--- a/src/com/digero/common/abctomidi/AbcInfo.java
+++ b/src/com/digero/common/abctomidi/AbcInfo.java
@@ -12,8 +12,10 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.prefs.Preferences;
 import java.util.regex.Pattern;
 
+import com.digero.abcplayer.AbcPlayer;
 import com.digero.common.abc.AbcConstants;
 import com.digero.common.abc.AbcField;
 import com.digero.common.abc.LotroInstrument;
@@ -235,6 +237,8 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 		return info.instrumentIsFromMadeFor;
 	}
 
+	public String getIssue() { return Util.emptyIfNull(issue); }
+
 	public int getPartCount() {
 		return partInfoByIndex.size();
 	}
@@ -436,9 +440,11 @@ public class AbcInfo implements AbcConstants, IBarNumberCache {
 			if (issue != null) {
 				String title = songTitle != null ? songTitle: "";
 				log.warning("Potential corrupted ABC. "+title+" ABC was exported with a flawed Maestro: "+issue);
-                SwingUtilities.invokeLater(() -> {
-                    JOptionPane.showMessageDialog(null, title+" ABC was exported with a flawed Maestro: "+issue, "Potential corrupted ABC from "+abcCreator, JOptionPane.WARNING_MESSAGE);
-                });
+				if (Preferences.userNodeForPackage(AbcPlayer.class).node("miscSettings").getBoolean("flawedMaestroPopup", true)) {
+					SwingUtilities.invokeLater(() -> {
+						JOptionPane.showMessageDialog(null, title+" ABC was exported with a flawed Maestro: "+issue, "Potential corrupted ABC from "+abcCreator, JOptionPane.WARNING_MESSAGE);
+					});
+				}
 			}
 			break;
 		case ABC_VERSION:

--- a/src/com/digero/maestro/abc/LotroChromaticFXInfo.java
+++ b/src/com/digero/maestro/abc/LotroChromaticFXInfo.java
@@ -53,7 +53,7 @@ public class LotroChromaticFXInfo extends LotroEventInfo<LotroChromaticFXInfo> {
 
     public static List<LotroChromaticFXInfo> getRange(LotroInstrument lotroInstrument) {
         return switch (lotroInstrument) {
-            case LotroInstrument.JAUNTY_HAND_KNELLS -> JAUNTY_FX;
+            case JAUNTY_HAND_KNELLS -> JAUNTY_FX;
             default -> null;
         };
     }
@@ -64,7 +64,7 @@ public class LotroChromaticFXInfo extends LotroEventInfo<LotroChromaticFXInfo> {
 
 	public static LotroChromaticFXInfo getById(LotroInstrument instrument, int noteId) {
 		return switch (instrument) {
-            case LotroInstrument.JAUNTY_HAND_KNELLS -> JAUNTY_BY_ID.get(noteId);
+            case JAUNTY_HAND_KNELLS -> JAUNTY_BY_ID.get(noteId);
             default -> null;
         };
 	}


### PR DESCRIPTION
Add abcplayer options to disable corrupt ABC popup, and add it to tooltip text in title labels and playlist hover