### PR TITLE
Improve README Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Maestro
+
 These tools were created by Digero of Landroval.
 
 They are being maintained and further developed by Aifel of Meriadoc and Elamond of Peregrin.
@@ -5,6 +7,6 @@ They are being maintained and further developed by Aifel of Meriadoc and Elamond
 Karloman has contributed to the code.
 
 XG, GS and GM2 instrument and drum kit names (but not drum hit names) taken mostly from:
-https://github.com/jazz-soft/JZZ-midi-GM
+<https://github.com/jazz-soft/JZZ-midi-GM>
 
 The code is open-source, licensed under MIT.


### PR DESCRIPTION
Hi Nikolai,

I noticed that the README file didn't have a top-level heading. This pull request therefore adds `# Maestro` and formats the URL as a Markdown autolink.

Feel free to close this pull request if you prefer not to change the README file's formatting.

I don't mean to be pushy, especially since this is my first contribution to this project. However, I've noticed a few things I'd like to share my thoughts on:

- The `master` branch seems to be older, while the most recent changes appear to be on the `java24` branch. It might be a good idea to set this branch as the repository's default, or perhaps rename/copy it to `main` or `master`.

- The Maven compiler configuration seems to be targeting Java 21 despite the branch name.

- Eclipse metadata files like `.classpath`, `.project`, and `.settings/` are tracked in version control. If these are no longer intentionally part of the project configuration, they could potentially be removed from version control and added to `.gitignore` in a separate cleanup pull request.

Regards, 
BinaryBaggins
Asgloin of Meriadoc