### PR TITLE
Refactor timing handling by replacing TimingEnum with TimingMode and …

### DIFF
--- a/src/com/digero/maestro/abc/AbcSong.java
+++ b/src/com/digero/maestro/abc/AbcSong.java
@@ -61,6 +61,7 @@ import com.digero.maestro.util.FileResolver;
 import com.digero.maestro.util.ListModelWrapper;
 import com.digero.maestro.util.SaveUtil;
 import com.digero.maestro.util.XmlUtil;
+import com.digero.maestro.view.TimingMode;
 
 public class AbcSong implements IDiscardable, AbcMetadataSource {
 	protected static final Logger log = Logger.getLogger("song");
@@ -230,7 +231,8 @@ public class AbcSong implements IDiscardable, AbcMetadataSource {
 			throws IOException, InvalidMidiDataException, FileParseException {
 		sourceFile = file;
 		usingOldVelocities = miscSettings.ignoreExpressionMessages;
-		ProjectFrame.TimingEnum.getFromSettings(saveSettings.defaultTiming).action(this);
+		TimingMode mode = TimingMode.getFromSettings(saveSettings.defaultTiming);
+		setTimings(mode.organic, mode.multistage, mode.mixTimings, mode.swing, mode.priority, mode.upgraded);
 		sequenceInfo = SequenceInfo.fromMidi(file, miscSettings, usingOldVelocities, usingOldTempos, false, false, usingNewMidiLayout);
 		title = sequenceInfo.getTitle();
 		composer = sequenceInfo.getComposer();

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -146,7 +146,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private JButton resetTempoButton;
 	private JFormattedTextField keySignatureField;
 	private JFormattedTextField timeSignatureField;
-    private JComboBox<TimingEnum> timingCombo;
+    private JComboBox<TimingMode> timingCombo;
 
     private JCheckBox tempoOnlyFirstCheckBox;
 	private JComboBox<Chord.CalcDynamics> dynaCombo;
@@ -675,13 +675,15 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			});
 		}
 
-        timingCombo = new JComboBox<>(TimingEnum.values());
+        timingCombo = new JComboBox<>(TimingMode.values());
 
         timingCombo.addActionListener(e -> {
-            TimingEnum enm = ((TimingEnum) Objects.requireNonNull(timingCombo.getSelectedItem()));
-            timingCombo.setToolTipText(enm.getTooltip());
+            TimingMode mode = (TimingMode) Objects.requireNonNull(timingCombo.getSelectedItem());
+            timingCombo.setToolTipText(mode.getTooltip());
 
-            enm.action(abcSong);
+            if (abcSong != null) {
+                abcSong.setTimings(mode.organic, mode.multistage, mode.mixTimings, mode.swing, mode.priority, mode.upgraded);
+            }
 
             refreshPreviewSequence(false);
         });
@@ -1889,7 +1891,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				// one or more timing settings were change in abc song
 
 				// setting on model dont fire action listener
-				timingCombo.getModel().setSelectedItem(TimingEnum.getInstance(abcSong.isOrganic(), abcSong.isOrganic2(), abcSong.isMixTiming(), abcSong.isTripletTiming(), abcSong.isPriorityActive(), abcSong.isUpgraded()));
+				timingCombo.getModel().setSelectedItem(TimingMode.getInstance(abcSong.isOrganic(), abcSong.isOrganic2(), abcSong.isMixTiming(), abcSong.isTripletTiming(), abcSong.isPriorityActive(), abcSong.isUpgraded()));
 
 				updateButtons(false);
 				break;
@@ -2208,7 +2210,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		tempoSpinner.setValue(MidiConstants.DEFAULT_TEMPO_BPM);
 		keySignatureField.setValue(KeySignature.C_MAJOR);
 		timeSignatureField.setValue(TimeSignature.FOUR_FOUR);
-        timingCombo.getModel().setSelectedItem(TimingEnum.MIX);
+        timingCombo.getModel().setSelectedItem(TimingMode.MIX);
         dynaCombo.setSelectedItem(AbcSong.dynamicsMethodDefault);
         tempoOnlyFirstCheckBox.setSelected(false);
 		midiBarLabel.setBarNumberCache(null);
@@ -2317,7 +2319,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			setMeter(abcSong.getTimeSignature());
 
             // setting on model dont fire action listener
-            timingCombo.getModel().setSelectedItem(TimingEnum.getInstance(abcSong.isOrganic(),abcSong.isOrganic2(),abcSong.isMixTiming(),abcSong.isTripletTiming(),abcSong.isPriorityActive(), abcSong.isUpgraded()));
+            timingCombo.getModel().setSelectedItem(TimingMode.getInstance(abcSong.isOrganic(),abcSong.isOrganic2(),abcSong.isMixTiming(),abcSong.isTripletTiming(),abcSong.isPriorityActive(), abcSong.isUpgraded()));
 
             tempoOnlyFirstCheckBox.setSelected(abcSong.isUsingOldTempos());
 
@@ -3631,96 +3633,6 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
                     log.log(Level.WARNING, "Failed to connect to github for version check", e);
                 }
             });
-        }
-    }
-
-    public enum TimingEnum {
-        ORGANIC_MULTISTAGE2 (UIText.get("maestro.timing.organic.multi.stage.2"),true, true, false,false,false,"Organic Multistage 2", true),
-        ORGANIC_MULTISTAGE (UIText.get("maestro.timing.organic.multi.stage"),true, true, false,false,false,"Organic Multistage", false),
-        ORGANIC_SINGLESTAGE (UIText.get("maestro.timing.organic.single.stage"), true, false, false,false,false,"Organic Singlestage", false),
-        MIX (UIText.get("maestro.timing.mix.timings"), false, false, true,false,false,"Mix Timings", false),
-        MIX_SWING (UIText.get("maestro.timing.mix.timings.swing"), false, false, true,true,false,"Mix Timings Swing/Triplet", false),
-        MIX_PRIO (UIText.get("maestro.timing.mix.timings.combine.priorities"), false, false, true,false,true,"Mix Timings Combine Priorities", false),
-        MIX_SWING_PRIO (UIText.get("maestro.timing.mix.timings.swing.combine.priorities"), false, false, true,true,true,"Mix Timings Swing/Triplet Combine Priorities", false),
-        LEGACY (UIText.get("maestro.timing.legacy.timings"), false, false, false,false,false,"Legacy", false),
-        LEGACY_SWING (UIText.get("maestro.timing.legacy.timings.swing"), false, false, false,true,false,"Legacy Swing/Triplet", false),
-        ;
-
-        public final boolean organic;
-        public final boolean multistage;
-        public final boolean mixTimings;
-        public final boolean swing;
-        public final boolean priority;
-        public final String info;
-        public final String settingsString;// use this for settings prefs. And never change the strings.
-        public final boolean upgraded;
-
-        TimingEnum(String info, boolean organic, boolean multistage, boolean mixTimings, boolean swing, boolean priority, @NonNls String settings, boolean upgraded) {
-            this.info = info;
-            this.organic = organic;
-            this.multistage = multistage;
-            this.mixTimings = mixTimings;
-            this.swing = swing;
-            this.priority = priority;
-            this.settingsString = settings;
-            this.upgraded = upgraded;
-        }
-
-        public static TimingEnum getFromSettings(String defaultTiming) {
-            Objects.requireNonNull(defaultTiming);
-            for (TimingEnum timing : TimingEnum.values()) {
-                if (timing.settingsString.equals(defaultTiming)) {
-                    return timing;
-                }
-            }
-            return MIX;
-        }
-
-        public void action(@Nullable AbcSong abcSong) {
-            if (abcSong != null) {
-                abcSong.setTimings(organic, multistage, mixTimings, swing, priority, upgraded);
-            }
-        }
-
-        String getTooltip() {
-            return switch (this) {
-                case ORGANIC_MULTISTAGE2 -> UIText.get("maestro.tip.multi2");
-                case ORGANIC_MULTISTAGE -> UIText.get("maestro.tip.multi1");
-                case ORGANIC_SINGLESTAGE -> UIText.get("maestro.tip.single");
-                case LEGACY -> UIText.get("maestro.tip.legacy");
-                case LEGACY_SWING -> UIText.get("maestro.tip.legacy.swing");
-                case MIX_SWING_PRIO -> UIText.get("maestro.tip.mix.swing.prio");
-                case MIX -> UIText.get("maestro.tip.mix");
-                case MIX_SWING -> UIText.get("maestro.tip.mix.swing");
-                case MIX_PRIO -> UIText.get("maestro.tip.mix.prio");
-                default -> null;
-            };
-        }
-
-        static TimingEnum getInstance(boolean organic, boolean multistage, boolean mixTimings, boolean swing, boolean priority, boolean upgraded) {
-            if (organic) {
-                if (multistage) {
-                    if (upgraded) return ORGANIC_MULTISTAGE2;
-                    return ORGANIC_MULTISTAGE;
-                }
-                else return ORGANIC_SINGLESTAGE;
-            } else if (mixTimings) {
-                if (swing) {
-                    if (priority) return MIX_SWING_PRIO;
-                    else return MIX_SWING;
-                } else {
-                    if (priority) return MIX_PRIO;
-                    else return MIX;
-                }
-            } else {
-                if (swing) return LEGACY_SWING;
-                else return LEGACY;
-            }
-        }
-
-        @Override
-        public String toString() {
-            return info;
         }
     }
 }

--- a/src/com/digero/maestro/view/SaveAndExportSettings.java
+++ b/src/com/digero/maestro/view/SaveAndExportSettings.java
@@ -12,7 +12,7 @@ public class SaveAndExportSettings {
 	public boolean useRestsInChords = false;
     public boolean warnOnExportOfSamePartNames = true;
     public boolean reducedFilesize = false;
-	public String defaultTiming = ProjectFrame.TimingEnum.ORGANIC_SINGLESTAGE.settingsString;
+	public String defaultTiming = TimingMode.ORGANIC_SINGLESTAGE.settingsString;
 	// public boolean showPruned = false;
 	public boolean convertABCStringsToBasicAscii = true;
 	public boolean countUpLyrics = false;

--- a/src/com/digero/maestro/view/SettingsDialog.java
+++ b/src/com/digero/maestro/view/SettingsDialog.java
@@ -844,20 +844,20 @@ public class SettingsDialog extends JDialog implements TableLayoutConstants {
 				e -> saveSettings.convertABCStringsToBasicAscii = convertABCStringsToBasicAsciiCheckBox.isSelected());
 		
 		final JLabel defaultTimingText = new JLabel(UIText.get("maestro.options.default.timing"));
-		final JComboBox<ProjectFrame.TimingEnum> defaultTimingComboBox = new JComboBox<>();
+		final JComboBox<TimingMode> defaultTimingComboBox = new JComboBox<>();
 		defaultTimingComboBox.setToolTipText(
 				UIText.get("maestro.options.html.select.default.timing.for.new.projects.from.midi.html"));
-		for (ProjectFrame.TimingEnum choice : ProjectFrame.TimingEnum.values()) {
+		for (TimingMode choice : TimingMode.values()) {
 			defaultTimingComboBox.addItem(choice);
 		}
 		defaultTimingComboBox.setEditable(false);
 		defaultTimingComboBox.addActionListener(e -> {
 			try {
-				saveSettings.defaultTiming = ((ProjectFrame.TimingEnum) Objects.requireNonNull(defaultTimingComboBox.getSelectedItem())).settingsString;
+				saveSettings.defaultTiming = ((TimingMode) Objects.requireNonNull(defaultTimingComboBox.getSelectedItem())).settingsString;
 			} catch (Exception ignored) {
 			}
 		});
-		defaultTimingComboBox.setSelectedItem(ProjectFrame.TimingEnum.getFromSettings(saveSettings.defaultTiming));
+		defaultTimingComboBox.setSelectedItem(TimingMode.getFromSettings(saveSettings.defaultTiming));
 		
 		final JCheckBox exceed6CheckBox = new JCheckBox(
 				UIText.get("maestro.options.allow.more.than.6.note.polyphony.in.parts.organic.only"));

--- a/src/com/digero/maestro/view/TimingMode.java
+++ b/src/com/digero/maestro/view/TimingMode.java
@@ -1,0 +1,93 @@
+package com.digero.maestro.view;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.Nullable;
+
+import com.digero.common.view.UIText;
+import com.digero.maestro.abc.AbcSong;
+
+public enum TimingMode {
+        ORGANIC_MULTISTAGE2 (UIText.get("maestro.timing.organic.multi.stage.2"),true, true, false,false,false,"Organic Multistage 2", true),
+        ORGANIC_MULTISTAGE (UIText.get("maestro.timing.organic.multi.stage"),true, true, false,false,false,"Organic Multistage", false),
+        ORGANIC_SINGLESTAGE (UIText.get("maestro.timing.organic.single.stage"), true, false, false,false,false,"Organic Singlestage", false),
+        MIX (UIText.get("maestro.timing.mix.timings"), false, false, true,false,false,"Mix Timings", false),
+        MIX_SWING (UIText.get("maestro.timing.mix.timings.swing"), false, false, true,true,false,"Mix Timings Swing/Triplet", false),
+        MIX_PRIO (UIText.get("maestro.timing.mix.timings.combine.priorities"), false, false, true,false,true,"Mix Timings Combine Priorities", false),
+        MIX_SWING_PRIO (UIText.get("maestro.timing.mix.timings.swing.combine.priorities"), false, false, true,true,true,"Mix Timings Swing/Triplet Combine Priorities", false),
+        LEGACY (UIText.get("maestro.timing.legacy.timings"), false, false, false,false,false,"Legacy", false),
+        LEGACY_SWING (UIText.get("maestro.timing.legacy.timings.swing"), false, false, false,true,false,"Legacy Swing/Triplet", false),
+        ;
+
+        public final boolean organic;
+        public final boolean multistage;
+        public final boolean mixTimings;
+        public final boolean swing;
+        public final boolean priority;
+        public final String info;
+        public final String settingsString;// use this for settings prefs. And never change the strings.
+        public final boolean upgraded;
+
+        TimingMode(String info, boolean organic, boolean multistage, boolean mixTimings, boolean swing, boolean priority, @NonNls String settings, boolean upgraded) {
+            this.info = info;
+            this.organic = organic;
+            this.multistage = multistage;
+            this.mixTimings = mixTimings;
+            this.swing = swing;
+            this.priority = priority;
+            this.settingsString = settings;
+            this.upgraded = upgraded;
+        }
+
+        public static TimingMode getFromSettings(String defaultTiming) {
+            Objects.requireNonNull(defaultTiming);
+            for (TimingMode timing : TimingMode.values()) {
+                if (timing.settingsString.equals(defaultTiming)) {
+                    return timing;
+                }
+            }
+            return MIX;
+        }
+
+        String getTooltip() {
+            return switch (this) {
+                case ORGANIC_MULTISTAGE2 -> UIText.get("maestro.tip.multi2");
+                case ORGANIC_MULTISTAGE -> UIText.get("maestro.tip.multi1");
+                case ORGANIC_SINGLESTAGE -> UIText.get("maestro.tip.single");
+                case LEGACY -> UIText.get("maestro.tip.legacy");
+                case LEGACY_SWING -> UIText.get("maestro.tip.legacy.swing");
+                case MIX_SWING_PRIO -> UIText.get("maestro.tip.mix.swing.prio");
+                case MIX -> UIText.get("maestro.tip.mix");
+                case MIX_SWING -> UIText.get("maestro.tip.mix.swing");
+                case MIX_PRIO -> UIText.get("maestro.tip.mix.prio");
+                default -> null;
+            };
+        }
+
+        static TimingMode getInstance(boolean organic, boolean multistage, boolean mixTimings, boolean swing, boolean priority, boolean upgraded) {
+            if (organic) {
+                if (multistage) {
+                    if (upgraded) return ORGANIC_MULTISTAGE2;
+                    return ORGANIC_MULTISTAGE;
+                }
+                else return ORGANIC_SINGLESTAGE;
+            } else if (mixTimings) {
+                if (swing) {
+                    if (priority) return MIX_SWING_PRIO;
+                    else return MIX_SWING;
+                } else {
+                    if (priority) return MIX_PRIO;
+                    else return MIX;
+                }
+            } else {
+                if (swing) return LEGACY_SWING;
+                else return LEGACY;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return info;
+        }
+    }


### PR DESCRIPTION
This pull request refactors the handling of timing modes throughout the Maestro application by replacing the `TimingEnum` enum (previously defined inside `ProjectFrame.java`) with a new, dedicated `TimingMode` enum class. All references and logic previously using `TimingEnum` are updated to use `TimingMode`.

Key changes include:

**Timing mode refactor:**

* Introduced a new `TimingMode` enum in its own file (`TimingMode.java`), moving all timing-related logic and properties out of `ProjectFrame.java` for better separation of concerns.
* Removed the old `TimingEnum` definition and all its usages from `ProjectFrame.java`, updating all relevant logic to use `TimingMode` instead.

**Codebase updates to use `TimingMode`:**

* Updated all timing-related UI components (`JComboBox`, etc.) in `ProjectFrame.java` and `SettingsDialog.java` to use `TimingMode` instead of `TimingEnum`, including initialization, event handling, and model updates.
* Updated the default timing setting in `SaveAndExportSettings.java` to use `TimingMode` instead of the removed `TimingEnum`. 
* Updated `AbcSong.java` to use the new `TimingMode` class for setting timing properties when initializing from MIDI files.