### PR TITLE
Fix/restore coalesced UI refresh

### DIFF
--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -328,7 +328,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			arrangementView.setAbcPart(abcPart, false);
 
 			if (abcPart != null) {
-				refreshUi();
+				scheduleUiRefresh();
 			} else {
 				if (songPartsListPanel.getModel().getSize() > 0) {
 					// If ctrl-clicking to deselect this will ensure something is selected
@@ -445,7 +445,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		/* refreshUi once to set the initial state of the UI.
 		This is needed in case a MIDI file is loaded by default or on first run,
 		and also to set the correct state of the UI when no song is loaded. */
-		refreshUi();
+		scheduleUiRefresh();
     }
 
 	/**
@@ -949,7 +949,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		}
 
 		curSequencer.setRunning(running);
-		refreshUi();
+		scheduleUiRefresh();
 	}
 
 	private JSplitPane generateTopLevelSplitPane() {
@@ -1466,7 +1466,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 			sequencer.setTickPosition(tick);
 			if (running) sequencer.setRunning(true); 
 		}
-		refreshUi();
+		scheduleUiRefresh();
         if (needRefresh) refreshPreviewSequence(false);
 	}
 	
@@ -1545,7 +1545,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private class MainSequencerListener implements Listener<SequencerEvent> {
 		@Override
 		public void onEvent(SequencerEvent evt) {
-			refreshUi();
+			scheduleUiRefresh();
 			if (evt.getProperty() == SequencerProperty.IS_RUNNING) {
 				if (sequencer.isRunning()) {
 					abcSequencer.stop();
@@ -1583,7 +1583,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private class AbcSequencerListener implements Listener<SequencerEvent> {
 		@Override
 		public void onEvent(SequencerEvent evt) {
-			refreshUi();
+			scheduleUiRefresh();
 			if (evt.getProperty() == SequencerProperty.IS_RUNNING) {
 				if (abcSequencer.isRunning()) {
 					sequencer.stop();
@@ -1649,7 +1649,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	 * Event Dispatch Thread, the update runs immediately. Otherwise, it is
 	 * scheduled on the Event Dispatch Thread.</p>
 	 *
-	 * @deprecated Use {@link #refreshUi()} instead, which automatically handles scheduling on the Event Dispatch Thread.
+	 * @deprecated Use {@link #scheduleUiRefresh()} instead, which automatically handles scheduling on the Event Dispatch Thread.
 	 * @param immediate whether to update immediately when already on the EDT
 	 */
 	@Deprecated(forRemoval = true)
@@ -1662,28 +1662,27 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	}
 
 	/**
-	 * Refreshes the UI state and error feed. If called from a non-Event Dispatch Thread,
-	 * the update is scheduled to run on the Event Dispatch Thread if not already pending..
+	 * Schedules a UI-state update to run on the Event Dispatch Thread.
+	 * If an update is already pending, this method does nothing.
+	 * 
+	 * TODO: This method should be enhanced to allow granular updates, e.g., only updating certain parts of the UI state instead of the entire state.
 	 */
-	void refreshUi() {
-		if (SwingUtilities.isEventDispatchThread()) {
-        	refreshUiStateAndFeed();
-        	return;
-    	}
-
+	void scheduleUiRefresh() {
     	if (uiRefreshPending.compareAndSet(false, true)) {
         	SwingUtilities.invokeLater(uiRefreshTask);
     	}
 	}
 
 	/**
-	 * Runnable task for refreshing the UI state and error feed.
+	 * The task that performs the UI-state update and refreshes the error feed.
+	 * This task is executed on the Event Dispatch Thread.
 	 */
 	private final Runnable uiRefreshTask = () -> {
-			// The request is no longer pending once its execution begins.
-    		// Another thread may now schedule a subsequent refresh if necessary.
-			uiRefreshPending.set(false);
-			refreshUiStateAndFeed();
+			try {
+				refreshUiStateAndFeed();
+			} finally {
+				uiRefreshPending.set(false);
+			}
 	};
 
 	/**
@@ -1933,7 +1932,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
         }
 
 		if (e.getProperty() == AbcPartProperty.TRACK_ENABLED)
-			refreshUi();
+			scheduleUiRefresh();
 
 		if (e.getProperty() == AbcPartProperty.TITLE && arrangementView != null)
 			arrangementView.setNewTitle(e.getSource());
@@ -2013,7 +2012,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				// setting on model dont fire action listener
 				timingCombo.getModel().setSelectedItem(TimingMode.getInstance(abcSong.isOrganic(), abcSong.isOrganic2(), abcSong.isMixTiming(), abcSong.isTripletTiming(), abcSong.isPriorityActive(), abcSong.isUpgraded()));
 
-				refreshUi();
+				scheduleUiRefresh();
 				break;
 			case CALC_DYNAMICS:
 				setDyna(abcSong.dynamicsMethod);
@@ -2026,7 +2025,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				songPartsListPanel.ensureIndexIsVisible(idx);
 				songPartsListPanel.repaint();
 				partEditor.repaint();
-				refreshUi();
+				scheduleUiRefresh();
 				compileStats();
 				break;
 			case BADGER:
@@ -2038,11 +2037,11 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				songPartsListPanel.repaint();
 				partEditor.updateParts();
 				partEditor.repaint();
-				refreshUi();
+				scheduleUiRefresh();
 				modified = false;
 				break;
 			case TUNE_EDIT:
-				refreshUi();
+				scheduleUiRefresh();
 				if (songPartsListPanel.getSelectedPart() != null) {
 					// We do this to show the tempo panel if the tune editor has changed something
 					arrangementView.setAbcPart(songPartsListPanel.getSelectedPart(), true);
@@ -2074,7 +2073,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				}
 
 				songPartsListPanel.repaint();
-				refreshUi();
+				scheduleUiRefresh();
 				break;
 			case AFTER_PART_REMOVED:
 				refreshPreviewSequence(false);
@@ -2090,7 +2089,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 				refreshPreviewSequence(false);// autoPan depend on part order
 				songPartsListPanel.repaint();
 				partEditor.repaint();
-				refreshUi();
+				scheduleUiRefresh();
 				break;
 
 			case SKIP_SILENCE_AT_START:
@@ -2156,21 +2155,21 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		public void intervalAdded(ListDataEvent e) {
 			songPartsListPanel.updateParts();
 			partEditor.updateParts();
-			refreshUi();
+			scheduleUiRefresh();
 		}
 
 		@Override
 		public void intervalRemoved(ListDataEvent e) {
 			songPartsListPanel.updateParts();
 			partEditor.updateParts();
-			refreshUi();
+			scheduleUiRefresh();
 		}
 
 		@Override
 		public void contentsChanged(ListDataEvent e) {
 			songPartsListPanel.updateParts();
 			partEditor.updateParts();
-			refreshUi();
+			scheduleUiRefresh();
 		}
 	};
 
@@ -2346,7 +2345,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		abcPositionLabel.setInitialOffsetTick(abcPreviewStartTick);
 
 		setAbcSongModified(false);
-		refreshUi();
+		scheduleUiRefresh();
 		updateTitle();
 
 		return true;
@@ -2474,16 +2473,16 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 
 			if (abcSong.isFromAbcFile() || abcSong.isFromXmlFile()) {
 				if (abcSong.getParts().isEmpty()) {
-					refreshUi();
+					scheduleUiRefresh();
 					abcSong.createNewPart();
 				} else {
 					songPartsListPanel.selectPart(0);
 					boolean autoplay = miscSettings.autoplayOnOpen;
 					updatePreviewMode(true, autoplay);
-					refreshUi();
+					scheduleUiRefresh();
 				}
 			} else {
-				refreshUi();
+				scheduleUiRefresh();
 				if (abcSong.getParts().isEmpty()) {
 					abcSong.createNewPart();
 				}
@@ -2761,7 +2760,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
             SequencerWrapper.isAbcPreview = abcPreviewMode;
 
 			arrangementView.setAbcPreviewMode(abcPreviewMode);
-			refreshUi();
+			scheduleUiRefresh();
 		}
 		if (abcPreviewMode) {
 			long tick = abcSequencer.getTickPosition();
@@ -3469,7 +3468,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
      */
     private void setSourceChangeEnabled(boolean on) {
         sourceChangeEnabled = on;
-        refreshUi();
+        scheduleUiRefresh();
     }
 
     /**

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1666,6 +1666,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	 * If an update is already pending, this method does nothing.
 	 * 
 	 * TODO: This method should be enhanced to allow granular updates, e.g., only updating certain parts of the UI state instead of the entire state.
+	 * This could further be enhanced by also coalescing multiple granular updates into a single update.
 	 */
 	void scheduleUiRefresh() {
     	if (uiRefreshPending.compareAndSet(false, true)) {
@@ -1716,7 +1717,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		disappear instead of happening as a side effect of refreshing
 		the UI? */
 		ensureValidPreviewMode(hasAbcNotes);
-		
+
 		updatePlaybackControls(midiLoaded, hasAbcNotes);
 		updateFileActions(currentSong, hasAbcNotes);
 		updateSourceControls(midiLoaded, hasProjectFile);

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1708,7 +1708,15 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		boolean hasProjectFile = currentSong != null && currentSong.getProjectFile() != null;
 
 		updatePlaybackIcons();
+
+		/*ensureValidPreviewMode() is not purely a UI update:
+		it can stop and clear the ABC sequencer. Since this refresh
+		is now deferred and coalesced, should that sequencer cleanup
+		be triggered explicitly when the last enabled ABC notes
+		disappear instead of happening as a side effect of refreshing
+		the UI? */
 		ensureValidPreviewMode(hasAbcNotes);
+		
 		updatePlaybackControls(midiLoaded, hasAbcNotes);
 		updateFileActions(currentSong, hasAbcNotes);
 		updateSourceControls(midiLoaded, hasProjectFile);

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1643,25 +1643,6 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	private AtomicBoolean uiRefreshPending = new AtomicBoolean();
 
 	/**
-	 * Updates the UI controls based on the current application state.
-	 *
-	 * <p>If {@code immediate} is {@code true} and this method is called on the
-	 * Event Dispatch Thread, the update runs immediately. Otherwise, it is
-	 * scheduled on the Event Dispatch Thread.</p>
-	 *
-	 * @deprecated Use {@link #scheduleUiRefresh()} instead, which automatically handles scheduling on the Event Dispatch Thread.
-	 * @param immediate whether to update immediately when already on the EDT
-	 */
-	@Deprecated(forRemoval = true)
-	void updateButtons(boolean immediate) {
-    	if (immediate && SwingUtilities.isEventDispatchThread()) {
-        	refreshUiStateAndFeed();
-    	} else if (uiRefreshPending.compareAndSet(false, true)) {
-        	SwingUtilities.invokeLater(uiRefreshTask);
-    	}
-	}
-
-	/**
 	 * Schedules a UI-state update to run on the Event Dispatch Thread.
 	 * If an update is already pending, this method does nothing.
 	 * 

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -1674,15 +1674,14 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 	}
 
 	/**
-	 * The task that performs the UI-state update and refreshes the error feed.
-	 * This task is executed on the Event Dispatch Thread.
+	 * Performs the queued UI refresh on the Event Dispatch Thread.
+	 *
+	 * The pending flag is cleared before execution so that a state change caused
+	 * during the refresh can schedule one follow-up refresh.
 	 */
 	private final Runnable uiRefreshTask = () -> {
-			try {
-				refreshUiStateAndFeed();
-			} finally {
-				uiRefreshPending.set(false);
-			}
+		uiRefreshPending.set(false);
+		refreshUiStateAndFeed();
 	};
 
 	/**


### PR DESCRIPTION
## Summary

This pull request refactors how UI updates are triggered in `ProjectFrame` by replacing direct calls to `refreshUi()` with `scheduleUiRefresh()`. UI refresh requests are now deferred to the Event Dispatch Thread and coalesced, avoiding redundant full refreshes during bursts of related events.

Documentation and comments were updated accordingly, and follow-up notes were added for future granular refresh handling and for the non-UI side effects currently performed by `ensureValidPreviewMode()`.

## UI Update Refactoring:

* Replaced all calls to `refreshUi()` with `scheduleUiRefresh()` throughout `ProjectFrame.java`, ensuring UI updates are scheduled and coalesced on the EDT. [[1]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL331-R331) [[2]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL448-R448) [[3]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL952-R952) [[4]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1469-R1469) [[5]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1548-R1548) [[6]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1586-R1586) [[7]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1936-R1943) [[8]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2016-R2023) [[9]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2029-R2036) [[10]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2041-R2052) [[11]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2077-R2084) [[12]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2093-R2100) [[13]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2159-R2180) [[14]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2349-R2356) [[15]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2477-R2493) [[16]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL2764-R2771) [[17]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL3472-R3479)

## Documentation and Code Comments:

* Updated method documentation to deprecate `refreshUi()` in favor of `scheduleUiRefresh()`, and clarified the new scheduling behavior in method comments. [[1]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1652-R1652) [[2]](diffhunk://#diff-2702c26eb4d2333d15650d839dae3b3aef985e7991d111e55088ba3b290cf23fL1665-L1684)
* Added a TODO in the `scheduleUiRefresh()` method for future enhancement to support granular and coalesced UI updates.

## Behavioral Notes:

* Added a comment in `refreshUiState()` noting that `ensureValidPreviewMode()` is not purely a UI update and may require explicit handling outside of the new deferred update system.