### PR TITLE
alert-fix-91

### DIFF
--- a/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
+++ b/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
@@ -8,12 +8,60 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
-public class LotroInstrumentSampleDuration {
+public final class LotroInstrumentSampleDuration {
 	private static final Logger log = Logger.getLogger("file");
-	private static volatile LotroInstrumentSampleDuration instance = null;
-	private static Object lock = new Object();
+	private static final Object lock = new Object();
 	private static volatile Map<String, Map<Integer, Long>> db = null;
 
+	private LotroInstrumentSampleDuration() {
+		// private constructor to prevent instantiation
+	}
+
+	/**
+	 * Ensure that the database is initialized. If it is not, parse the
+	 * noteDurations.txt file to populate it.
+	 * 
+	 * @throws IOException if an I/O error occurs
+	 */
+	private static void ensureDbInitialized() throws IOException {
+		if (db == null) {
+			synchronized (lock) {
+				if (db == null) {
+					parse();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get duration of particular lotro instrument sample.
+	 * 
+	 * @param friendlyName Name of instrument
+	 * @param note         Note id
+	 * @return duration in seconds
+	 * @throws IOException if an I/O error occurs
+	 */
+	public static Long getDura(String friendlyName, int note) throws IOException {
+		ensureDbInitialized();
+
+		Map<Integer, Long> instr = db.get(friendlyName);
+		if (instr == null) {
+			return null;
+		}
+		if (friendlyName.equals(LotroInstrument.BASIC_COWBELL.friendlyName)
+				|| friendlyName.equals(LotroInstrument.MOOR_COWBELL.friendlyName)) {
+			note = AbcConstants.COWBELL_NOTE_ID;// 71
+		}
+		return instr.get(note);
+	}
+
+	/**
+	 * Get a safe duration for the given instrument, which is slightly less than the
+	 * actual sample duration to avoid issues with fading out.
+	 * 
+	 * @param instrument The instrument for which to get the safe duration
+	 * @return The safe duration in milliseconds
+	 */
 	public static long getSafeDuration(LotroInstrument instrument) {
 		return switch (instrument) {
 			// These have a safety buffer of around 0.5 seconds
@@ -36,54 +84,10 @@ public class LotroInstrumentSampleDuration {
 	}
 
 	/**
-	 * Get duration of particular lotro instrument sample.
+	 * Parse the noteDurations.txt file and populate the database.
 	 * 
-	 * @param friendlyName Name of instrument
-	 * @param note         Note id
-	 * @return duration in seconds
-	 * @throws IOException
-	 */
-	public static Long getDura(String friendlyName, int note) throws IOException {
-		if (db == null) {
-			synchronized (LotroInstrumentSampleDuration.class) {
-				if (db == null) {
-					parse();
-				}
-			}
-		}
-		Map<Integer, Long> instr = db.get(friendlyName);
-		if (instr == null) {
-			return null;
-		}
-		if (friendlyName.equals(LotroInstrument.BASIC_COWBELL.friendlyName)
-				|| friendlyName.equals(LotroInstrument.MOOR_COWBELL.friendlyName)) {
-			note = AbcConstants.COWBELL_NOTE_ID;// 71
-		}
-		return instr.get(note);
-	}
-
-	/**
-	 * Get the singleton instance of LotroInstrumentSampleDuration.
-	 * 
-	 * @return the singleton instance
 	 * @throws IOException if an I/O error occurs
 	 */
-	public static LotroInstrumentSampleDuration getInstance() throws IOException {
-		LotroInstrumentSampleDuration result = instance;
-		if (result == null) {
-			synchronized (lock) {
-				result = instance;
-				if (result == null) {
-					instance = new LotroInstrumentSampleDuration();
-					if (db == null)
-						parse();
-					instance = result;
-				}
-			}
-		}
-		return instance;
-	}
-
 	private static void parse() throws IOException {
 		String fileName = "noteDurations.txt";
 		Map<String, Map<Integer, Long>> tempDb = new HashMap<>();
@@ -99,6 +103,14 @@ public class LotroInstrumentSampleDuration {
 		db = tempDb;
 	}
 
+	/**
+	 * Read lines from the given file and populate the temporary database.
+	 * 
+	 * @param fileName      Name of the file being read
+	 * @param theFileReader BufferedReader for reading the file
+	 * @param tempDb        Temporary database to populate
+	 * @throws IOException if an I/O error occurs
+	 */
 	private static void readLines(String fileName, BufferedReader theFileReader, Map<String, Map<Integer, Long>> tempDb)
 			throws IOException {
 		String line = theFileReader.readLine();

--- a/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
+++ b/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
@@ -10,8 +10,8 @@ import java.util.logging.Logger;
 
 public class LotroInstrumentSampleDuration {
 	private static final Logger log = Logger.getLogger("file");
-	private static LotroInstrumentSampleDuration instance = null;
-	private static volatile Object lock = new Object();
+	private static volatile LotroInstrumentSampleDuration instance = null;
+	private static Object lock = new Object();
 	private static volatile Map<String, Map<Integer, Long>> db = null;
 
 	public static long getSafeDuration(LotroInstrument instrument) {

--- a/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
+++ b/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
@@ -92,14 +92,17 @@ public final class LotroInstrumentSampleDuration {
 		String fileName = "noteDurations.txt";
 		Map<String, Map<Integer, Long>> tempDb = new HashMap<>();
 		InputStream in = LotroInstrumentSampleDuration.class.getResourceAsStream(fileName);
+
 		if (in == null) {
 			log.severe(fileName + " not readable.");
 			db = tempDb;// this makes us get the error logged only once
 			return;
 		}
-		BufferedReader theFileReader = new BufferedReader(new InputStreamReader(in));
-		readLines(fileName, theFileReader, tempDb);
-		theFileReader.close();
+
+		try (BufferedReader theFileReader = new BufferedReader(new InputStreamReader(in))) {
+			readLines(fileName, theFileReader, tempDb);
+		}
+
 		db = tempDb;
 	}
 

--- a/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
+++ b/src/com/digero/common/abc/LotroInstrumentSampleDuration.java
@@ -11,36 +11,37 @@ import java.util.logging.Logger;
 public class LotroInstrumentSampleDuration {
 	private static final Logger log = Logger.getLogger("file");
 	private static LotroInstrumentSampleDuration instance = null;
+	private static volatile Object lock = new Object();
 	private static volatile Map<String, Map<Integer, Long>> db = null;
 
-    public static long getSafeDuration(LotroInstrument instrument) {
-        return switch (instrument) {
-            // These have a safety buffer of around 0.5 seconds
-            // to force them to be split before they fade out too much:
-            case LONELY_MOUNTAIN_FIDDLE -> 7_600_000L;
-            case BASIC_FIDDLE -> 6_500_000L;
-            case STUDENT_FIDDLE -> 6_500_000L;
-            case BASIC_BAGPIPE -> 6_000_000L;
-            case BASIC_HORN -> 5_750_000L;
-            case BARDIC_FIDDLE -> 5_500_000L;
-            case BASIC_PIBGORN -> 5_500_000L;
-            case BASIC_BASSOON -> 5_000_000L;
-            case BASIC_CLARINET -> 5_000_000L;
+	public static long getSafeDuration(LotroInstrument instrument) {
+		return switch (instrument) {
+			// These have a safety buffer of around 0.5 seconds
+			// to force them to be split before they fade out too much:
+			case LONELY_MOUNTAIN_FIDDLE -> 7_600_000L;
+			case BASIC_FIDDLE -> 6_500_000L;
+			case STUDENT_FIDDLE -> 6_500_000L;
+			case BASIC_BAGPIPE -> 6_000_000L;
+			case BASIC_HORN -> 5_750_000L;
+			case BARDIC_FIDDLE -> 5_500_000L;
+			case BASIC_PIBGORN -> 5_500_000L;
+			case BASIC_BASSOON -> 5_000_000L;
+			case BASIC_CLARINET -> 5_000_000L;
 
-            // These two are right on the edge of their minimum sample lengths:
-            case LONELY_MOUNTAIN_BASSOON -> 5_000_000L;
-            case BASIC_FLUTE -> 5_000_000L;
-            default -> 7_500_000L;// for rests
-        };
-    }
+			// These two are right on the edge of their minimum sample lengths:
+			case LONELY_MOUNTAIN_BASSOON -> 5_000_000L;
+			case BASIC_FLUTE -> 5_000_000L;
+			default -> 7_500_000L;// for rests
+		};
+	}
 
 	/**
 	 * Get duration of particular lotro instrument sample.
 	 * 
 	 * @param friendlyName Name of instrument
-	 * @param note Note id
+	 * @param note         Note id
 	 * @return duration in seconds
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	public static Long getDura(String friendlyName, int note) throws IOException {
 		if (db == null) {
@@ -50,28 +51,39 @@ public class LotroInstrumentSampleDuration {
 				}
 			}
 		}
-        Map<Integer, Long> instr = db.get(friendlyName);
-        if (instr == null) {
-            return null;
-        }
-		if (friendlyName.equals(LotroInstrument.BASIC_COWBELL.friendlyName) || friendlyName.equals(LotroInstrument.MOOR_COWBELL.friendlyName)) {
+		Map<Integer, Long> instr = db.get(friendlyName);
+		if (instr == null) {
+			return null;
+		}
+		if (friendlyName.equals(LotroInstrument.BASIC_COWBELL.friendlyName)
+				|| friendlyName.equals(LotroInstrument.MOOR_COWBELL.friendlyName)) {
 			note = AbcConstants.COWBELL_NOTE_ID;// 71
 		}
-        return instr.get(note);
+		return instr.get(note);
 	}
-	
+
+	/**
+	 * Get the singleton instance of LotroInstrumentSampleDuration.
+	 * 
+	 * @return the singleton instance
+	 * @throws IOException if an I/O error occurs
+	 */
 	public static LotroInstrumentSampleDuration getInstance() throws IOException {
-		if (instance == null) {
-			synchronized (LotroInstrumentSampleDuration.class) {
-				if (instance == null) {
+		LotroInstrumentSampleDuration result = instance;
+		if (result == null) {
+			synchronized (lock) {
+				result = instance;
+				if (result == null) {
 					instance = new LotroInstrumentSampleDuration();
-					if (db == null) parse();
+					if (db == null)
+						parse();
+					instance = result;
 				}
 			}
 		}
 		return instance;
 	}
-	
+
 	private static void parse() throws IOException {
 		String fileName = "noteDurations.txt";
 		Map<String, Map<Integer, Long>> tempDb = new HashMap<>();
@@ -81,13 +93,14 @@ public class LotroInstrumentSampleDuration {
 			db = tempDb;// this makes us get the error logged only once
 			return;
 		}
-		BufferedReader theFileReader = new BufferedReader(new InputStreamReader(in));			
+		BufferedReader theFileReader = new BufferedReader(new InputStreamReader(in));
 		readLines(fileName, theFileReader, tempDb);
 		theFileReader.close();
 		db = tempDb;
 	}
 
-	private static void readLines(String fileName, BufferedReader theFileReader, Map<String, Map<Integer, Long>> tempDb) throws IOException {
+	private static void readLines(String fileName, BufferedReader theFileReader, Map<String, Map<Integer, Long>> tempDb)
+			throws IOException {
 		String line = theFileReader.readLine();
 		while (line != null) {
 			if (line.isBlank() || line.startsWith("#")) {
@@ -97,19 +110,21 @@ public class LotroInstrumentSampleDuration {
 			String[] splits = line.split(",");
 			if (splits.length != 3) {
 				// Something is wrong in the tab formatting of one of the files
-				log.severe("Wrong number of entries in " + fileName + ": "+splits.length);
+				log.severe("Wrong number of entries in " + fileName + ": " + splits.length);
 				throw new IOException("Wrong number of entries in " + fileName + ": " + splits.length);
 			}
-			
+
 			String instr = splits[0].trim();
 			int note = Integer.parseInt(splits[1].trim());
 			long dura = Long.parseLong(splits[2].trim());
-            Map<Integer, Long> instrMap = tempDb.computeIfAbsent(instr, k -> new HashMap<>());
-            instrMap.put(note, dura);
-			if (instr.equals(LotroInstrument.BASIC_FIDDLE.friendlyName) && note >= LotroInstrument.STUDENT_CHROMATIC_LOWEST.id) {
+			Map<Integer, Long> instrMap = tempDb.computeIfAbsent(instr, k -> new HashMap<>());
+			instrMap.put(note, dura);
+			if (instr.equals(LotroInstrument.BASIC_FIDDLE.friendlyName)
+					&& note >= LotroInstrument.STUDENT_CHROMATIC_LOWEST.id) {
 				// Student fiddle needs the basic fiddle notes also above 42.
-                Map<Integer, Long> instrMap2 = tempDb.computeIfAbsent(LotroInstrument.STUDENT_FIDDLE.friendlyName, k -> new HashMap<>());
-                instrMap2.put(note, dura);
+				Map<Integer, Long> instrMap2 = tempDb.computeIfAbsent(LotroInstrument.STUDENT_FIDDLE.friendlyName,
+						k -> new HashMap<>());
+				instrMap2.put(note, dura);
 			}
 			line = theFileReader.readLine();
 		}


### PR DESCRIPTION

This pull request refactors and improves the `LotroInstrumentSampleDuration` class to make it thread-safe, non-instantiable, and easier to maintain. The singleton pattern is removed in favor of static utility methods, and lazy initialization is now handled with double-checked locking. Documentation has also been improved for better code clarity.

**Refactoring and Thread Safety:**
* Refactored `LotroInstrumentSampleDuration` to a `final` class with a private constructor, removed the singleton instance, and made all methods static to enforce non-instantiability and utility class usage. Double-checked locking is used for safe, lazy initialization of the internal database (`db`).
* Removed the `getInstance()` method and replaced direct database initialization with the new `ensureDbInitialized()` method, ensuring thread-safe, on-demand loading.

**API and Documentation Improvements:**
* Improved JavaDoc comments for public and private methods, clarifying method purposes and parameters. [[1]](diffhunk://#diff-de3527414dbd6305935cba0897626f180134f25510e771a49f54ec293c05c5eeL11-R64) [[2]](diffhunk://#diff-de3527414dbd6305935cba0897626f180134f25510e771a49f54ec293c05c5eeL38-L74) [[3]](diffhunk://#diff-de3527414dbd6305935cba0897626f180134f25510e771a49f54ec293c05c5eeL90-R115)
* Refactored and documented the `readLines` method to improve readability and maintainability.

**Code Cleanup and Logic Adjustments:**
* Cleaned up and clarified logic for handling special instrument cases (e.g., cowbells and fiddles) and improved code formatting.

These changes make the class safer for concurrent use, easier to understand, and more maintainable.