### PR TITLE
Alert fix 99

### DIFF
--- a/src/com/digero/maestro/midi/MidiText.java
+++ b/src/com/digero/maestro/midi/MidiText.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeSet;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.digero.common.midi.CharsetDetectAndDecode;
 import com.digero.common.midi.MidiUtils;
@@ -24,28 +22,24 @@ import com.digero.maestro.midi.MidiText.TextFragment.Format;
 
 public class MidiText {
 	private static final Logger log = Logger.getLogger("import.midi.text");
-	
-	private static final Pattern KARAKAN_PART_PATTERN = Pattern.compile("\\[P(\\d+)]");
-	private final SequenceDataCache cache;
+
 	public TreeSet<TextFragment> text = new TreeSet<>();
-	public Map<TextFragment.Format,Integer> textStats = new HashMap<>();
-	public Map<Integer,Integer> trackStats = new HashMap<>();
+	public Map<TextFragment.Format, Integer> textStats = new HashMap<>();
+	public Map<Integer, Integer> trackStats = new HashMap<>();
 	public String genre = "";
 	public String artist = "";
 	public String composer = "";
 	public String duration = "";
 	public String bpm = "";
 	// language=ENGL means if no language specified, we prefer western charset,
-	// language="" means only if language english is specified do we prefer western charset
+	// language="" means only if language english is specified do we prefer western
+	// charset
 	String language = "";
 	Format lastType = null;
 
-	private Map<Charset,Integer> csStats = new HashMap<>();
-	private int csTotal = 0;
 	private Charset mainCharset = null;
 
-	public MidiText(SequenceDataCache cache) {
-		this.cache = cache;
+	public MidiText() {
 	}
 
 	/**
@@ -56,16 +50,16 @@ public class MidiText {
 	}
 
 	private String decode(byte[] data, boolean storeCharset) {
-		Pair<String, Charset> result = MidiUtils.decodeMidiText(data, 
-				   "ENGL".equalsIgnoreCase(language)
-				|| "EN".equalsIgnoreCase(language)
-				|| "ENGLISH".equalsIgnoreCase(language)
-				|| "FREN".equalsIgnoreCase(language)
-				|| "FRENCH".equalsIgnoreCase(language)
-				|| "FR".equalsIgnoreCase(language)
-			);
-		//addToCharsetScore(result.second);
-		if (storeCharset) mainCharset = result.second;
+		Pair<String, Charset> result = MidiUtils.decodeMidiText(data,
+				"ENGL".equalsIgnoreCase(language)
+						|| "EN".equalsIgnoreCase(language)
+						|| "ENGLISH".equalsIgnoreCase(language)
+						|| "FREN".equalsIgnoreCase(language)
+						|| "FRENCH".equalsIgnoreCase(language)
+						|| "FR".equalsIgnoreCase(language));
+		// addToCharsetScore(result.second);
+		if (storeCharset)
+			mainCharset = result.second;
 		return result.first;
 	}
 
@@ -73,13 +67,14 @@ public class MidiText {
 	 * Decode with the charset detected from the getText() method.
 	 */
 	private String decodeWith(byte[] data) {
-		if (mainCharset == null) return decode(data);
-        return CharsetDetectAndDecode.decodeMidiData(data, mainCharset);
+		if (mainCharset == null)
+			return decode(data);
+		return CharsetDetectAndDecode.decodeMidiData(data, mainCharset);
 	}
-	
+
 	void collectTxt(long tick, byte[] data, int metaType, int track) {
 		boolean valid = false;
-		int offset = 0;		
+		int offset = 0;
 		TextFragment fragment = new TextFragment();
 		switch (metaType) {
 			case MidiConstants.META_TEXT:
@@ -98,7 +93,8 @@ public class MidiText {
 				fragment.source = Source.MLIVE;
 				break;
 		}
-		//System.out.println("tick="+tick+" txt: "+MidiUtils.formatBytesHexOnly(data)+" type="+fragment.source+" track="+track);
+		// System.out.println("tick="+tick+" txt: "+MidiUtils.formatBytesHexOnly(data)+"
+		// type="+fragment.source+" track="+track);
 		fragment.track = track;
 		fragment.tick = tick;
 		if (data != null && data.length > 0) {
@@ -130,10 +126,11 @@ public class MidiText {
 						fragment.prefix = "BPM: ";
 						break;
 					default:
-						log.severe("Unknown M-LIVE tag: "+data[0]+" -- "+ decode(Arrays.copyOfRange(data, offset, data.length)));
+						log.severe("Unknown M-LIVE tag: " + data[0] + " -- "
+								+ decode(Arrays.copyOfRange(data, offset, data.length)));
 						return;
 				}
-				
+
 				fragment.format = Format.UNKNOWN;
 				fragment.reaction = Reaction.META_LINE;
 				fragment.sylineBytes = Arrays.copyOfRange(data, offset, data.length);
@@ -172,7 +169,8 @@ public class MidiText {
 					fragment.reaction = Reaction.INFO;
 					offset = 2;
 					fragment.format = Format.UNKNOWN;
-					if (data.length == 6 && data[2] == (byte) 'E' && data[3] == (byte) 'N' && data[4] == (byte) 'G' && data[5] == (byte) 'L') {
+					if (data.length == 6 && data[2] == (byte) 'E' && data[3] == (byte) 'N' && data[4] == (byte) 'G'
+							&& data[5] == (byte) 'L') {
 						fragment.reaction = Reaction.LANGUAGE;
 					}
 				} else if (data[0] == (byte) '@' && data.length >= 2) {
@@ -183,21 +181,21 @@ public class MidiText {
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.RIGHTS;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						case 'L':
 						case 'l':
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.LANGUAGE;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						case 'T':
 						case 't':
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.TITLE;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						case 'W':
 						case 'w':
@@ -206,21 +204,21 @@ public class MidiText {
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.WRITER;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						case 'I':
 						case 'i':
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.INFO;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						case 'V':
 						case 'v':
 							valid = data.length > 2;
 							offset = 2;
 							fragment.reaction = Reaction.VERSION;
-							fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
+							fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
 							break;
 						default:
 							fragment.reaction = Reaction.META_LINE;
@@ -232,14 +230,15 @@ public class MidiText {
 					offset = 1;
 					fragment.reaction = Reaction.NEWLINE_OLD;
 					fragment.format = Format.SOFT_KARAOKE;
-					log.finest("Newline: "+MidiUtils.formatBytesHexOnly(Arrays.copyOfRange(data, offset, data.length)));
+					log.finest(
+							"Newline: " + MidiUtils.formatBytesHexOnly(Arrays.copyOfRange(data, offset, data.length)));
 					allowStitch = true;
 				} else if (data[0] == (byte) '\\' && fragment.source == Source.TEXT) {
 					valid = true;
 					offset = 1;
 					fragment.reaction = Reaction.CLEAR_OLD;
 					fragment.format = Format.SOFT_KARAOKE;
-					log.finest("Clear: "+MidiUtils.formatBytesHexOnly(data));
+					log.finest("Clear: " + MidiUtils.formatBytesHexOnly(data));
 				} else if (data[0] == (byte) '/' && fragment.source == Source.LYRIC) {
 					valid = true;
 					offset = 1;
@@ -251,14 +250,15 @@ public class MidiText {
 					offset = 1;
 					fragment.reaction = Reaction.CLEAR_NEW;
 					fragment.format = Format.UNKNOWN;
-					log.fine("Clear: "+MidiUtils.formatBytesHexOnly(data));
+					log.fine("Clear: " + MidiUtils.formatBytesHexOnly(data));
 				} else {
 					valid = true;
 					fragment.reaction = Reaction.SYLLABLE;
-					fragment.format = fragment.source == Source.TEXT?Format.SOFT_KARAOKE:Format.TUNE1000;
-					if (lastType != null && fragment.format != lastType) fragment.reaction = Reaction.NEWLINE_NEW;//should maybe be old
+					fragment.format = fragment.source == Source.TEXT ? Format.SOFT_KARAOKE : Format.TUNE1000;
+					if (lastType != null && fragment.format != lastType)
+						fragment.reaction = Reaction.NEWLINE_NEW;// should maybe be old
 					lastType = fragment.format;
-					//log.severe("Syllable: "+MidiUtils.formatBytesHexOnly(data));
+					// log.severe("Syllable: "+MidiUtils.formatBytesHexOnly(data));
 				}
 				// Check if this is a Newline_new event
 				// and if the prev fragment ended with a hyphen.
@@ -267,7 +267,7 @@ public class MidiText {
 
 					// Check if the last fragment ended with '-' (ASCII 45)
 					if (last.sylineBytes != null && last.sylineBytes.length > 0 &&
-							last.sylineBytes[last.sylineBytes.length - 1] == (byte)'-') {
+							last.sylineBytes[last.sylineBytes.length - 1] == (byte) '-') {
 						// In old kar files a newline was often inserted to
 						// break long lines so they fit on screen.
 						// So if we find the last syllable ended with hyphen,
@@ -283,9 +283,10 @@ public class MidiText {
 				if (valid) {
 					if (data.length - offset > 0) {
 						int end = data.length;
-						if (data[data.length-1] == (byte)'\r') {
-							if (data.length < 3 || data[data.length-2] != (byte)'-') {
-								if (fragment.reaction == Reaction.SYLLABLE) fragment.reaction = Reaction.NEWLINE_AFTER;
+						if (data[data.length - 1] == (byte) '\r') {
+							if (data.length < 3 || data[data.length - 2] != (byte) '-') {
+								if (fragment.reaction == Reaction.SYLLABLE)
+									fragment.reaction = Reaction.NEWLINE_AFTER;
 							}
 							end = Math.max(offset, end - 1);
 						}
@@ -301,9 +302,10 @@ public class MidiText {
 								return;
 							}
 						}
-						
-					    if (fragment.reaction == Reaction.LANGUAGE) language = decode(fragment.sylineBytes); 
-					}					
+
+						if (fragment.reaction == Reaction.LANGUAGE)
+							language = decode(fragment.sylineBytes);
+					}
 				}
 			}
 		}
@@ -314,32 +316,15 @@ public class MidiText {
 				log.fine(fragment.toString());
 			} else {
 				log.finer(MidiUtils.formatBytesHexOnly(data));
-                //fragment.syline = decode(fragment.sylineBytes);//for debug
+				// fragment.syline = decode(fragment.sylineBytes);//for debug
 				log.fine(fragment.toString());
 				increaseTextStats(fragment.format);
 				boolean ok = text.add(fragment);
-				if (!ok) log.warning("Dropped syllable");
+				if (!ok)
+					log.warning("Dropped syllable");
 				addToTrackScore(track, fragment);
 			}
 		}
-	}
-	
-	private boolean decodeKarakan(TextFragment fragment) {
-		String syllable = fragment.syline;
-		Matcher m = KARAKAN_PART_PATTERN.matcher(syllable);
-		List<Integer> parts = new ArrayList<>();
-	    while (m.find()) {
-	        parts.add(Integer.parseInt(m.group(1)));
-		}
-	    if (!parts.isEmpty() && !parts.contains(1)) {
-	    	// not vocal #1
-	    	fragment.format = Format.KARAKAN;
-	    	return false;
-	    } else if (!parts.isEmpty()) {
-	    	syllable = syllable.substring(4);
-	    	fragment.format = Format.KARAKAN;
-	    }
-	    return true;
 	}
 
 	void collectSysex(long tick, byte[] message, int track) {
@@ -380,7 +365,7 @@ public class MidiText {
 						break;
 				}
 				if (valid) {
-                    fragment.sylineBytes = Arrays.copyOfRange(message, 7, message.length - 1);
+					fragment.sylineBytes = Arrays.copyOfRange(message, 7, message.length - 1);
 					fragment.format = Format.MIDISOFT;
 					fragment.source = Source.SYSEX;
 					fragment.track = track;
@@ -391,55 +376,59 @@ public class MidiText {
 			}
 		}
 	}
-	
+
 	private void increaseTextStats(Format format) {
 		Integer count = textStats.get(format);
-		if (count == null) count = 0;
+		if (count == null)
+			count = 0;
 		count++;
 		textStats.put(format, count);
 	}
 
 	/**
 	 * 
-	 * @return string describing count of how many of each lyrics format was seen in song.
+	 * @return string describing count of how many of each lyrics format was seen in
+	 *         song.
 	 */
 	public String getTextStats() {
 		StringBuilder str = new StringBuilder();
 		for (Format type : Format.values()) {
 			Integer count = textStats.get(type);
 			if (count != null) {
-				if (!str.isEmpty()) str.append(", ");
+				if (!str.isEmpty())
+					str.append(", ");
 				str.append(type).append(": ").append(count);
 			}
 		}
 		return str.toString();
 	}
-	
+
 	/**
 	 * 
-	 * @param track a fragment was seen in certain track, increase the counter for number of fragments in that track.
+	 * @param track a fragment was seen in certain track, increase the counter for
+	 *              number of fragments in that track.
 	 */
 	private void addToTrackScore(int track, TextFragment frag) {
 		Integer curr = trackStats.get(track);
-		if (curr == null) curr = 0;
-		if (frag.syline != null && (
-			   frag.reaction == Reaction.LINE
-			|| frag.reaction == Reaction.FIRST
-			|| frag.reaction == Reaction.SECOND
-			|| frag.reaction == Reaction.THIRD
-			|| frag.reaction == Reaction.FOURTH
-			|| frag.reaction == Reaction.SYLLABLE
-			|| frag.reaction == Reaction.NEWLINE_NEW
-			|| frag.reaction == Reaction.NEWLINE_OLD
-			|| frag.reaction == Reaction.CLEAR_NEW
-			|| frag.reaction == Reaction.CLEAR_OLD
-			|| frag.reaction == Reaction.NEWLINE_AFTER)) {
-				curr += frag.sylineBytes.length;
-				//curr++;
+		if (curr == null)
+			curr = 0;
+		if (frag.syline != null && (frag.reaction == Reaction.LINE
+				|| frag.reaction == Reaction.FIRST
+				|| frag.reaction == Reaction.SECOND
+				|| frag.reaction == Reaction.THIRD
+				|| frag.reaction == Reaction.FOURTH
+				|| frag.reaction == Reaction.SYLLABLE
+				|| frag.reaction == Reaction.NEWLINE_NEW
+				|| frag.reaction == Reaction.NEWLINE_OLD
+				|| frag.reaction == Reaction.CLEAR_NEW
+				|| frag.reaction == Reaction.CLEAR_OLD
+				|| frag.reaction == Reaction.NEWLINE_AFTER)) {
+			curr += frag.sylineBytes.length;
+			// curr++;
 		}
 		trackStats.put(track, curr);
 	}
-	
+
 	/**
 	 * Calculate which track has the most lyrics and return that.
 	 * We simply ignore the other tracks, they often for chorus or duets.
@@ -453,28 +442,28 @@ public class MidiText {
 				winner = entry.getKey();
 				count = entry.getValue();
 			}
-			log.info("Track "+entry.getKey()+" text score: "+entry.getValue());
+			log.info("Track " + entry.getKey() + " text score: " + entry.getValue());
 		}
 		return winner;
 	}
-	
+
 	public String getText() {
 		StringBuilder str = new StringBuilder();
-		
+
 		if (text.isEmpty()) {
-			//important for abc tool that decoder don't get called,
-			//since its not present in its jar.
+			// important for abc tool that decoder don't get called,
+			// since its not present in its jar.
 			return str.toString();
 		}
 		int mainTrack = calcWinningTrack();
-        log.fine("Winning lyrics track: "+mainTrack);
+		log.fine("Winning lyrics track: " + mainTrack);
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 		/*
-		if (!cache.getCopyright().isEmpty()) {
-		 
-			str += "MIDI copyright: "+cache.getCopyright()+"\n";
-		}
-		*/
+		 * if (!cache.getCopyright().isEmpty()) {
+		 * 
+		 * str += "MIDI copyright: "+cache.getCopyright()+"\n";
+		 * }
+		 */
 		Reaction prev = null;
 		byte[] prevClear = {};
 		for (TextFragment fraction : text) {
@@ -484,31 +473,37 @@ public class MidiText {
 				case SECOND:
 				case THIRD:
 				case FOURTH:
-					if (fraction.track != mainTrack) break;
-					if (fraction.reaction == Reaction.FIRST) bytes.write(0x0A);
+					if (fraction.track != mainTrack)
+						break;
+					if (fraction.reaction == Reaction.FIRST)
+						bytes.write(0x0A);
 					writeTrimmed(bytes, fraction.sylineBytes);
 					bytes.write(0x0A);
 					break;
 				case SYLLABLE:
-					if (fraction.track != mainTrack) break;
+					if (fraction.track != mainTrack)
+						break;
 					writeTrimmed(bytes, fraction.sylineBytes);
 					break;
 				case NEWLINE_OLD:
-					if (fraction.track != mainTrack) break;
+					if (fraction.track != mainTrack)
+						break;
 					if (prev != Reaction.CLEAR_OLD || prevClear.length > 0) {
 						bytes.write(0x0A);
 					}
 					writeTrimmed(bytes, fraction.sylineBytes);
 					break;
 				case NEWLINE_NEW:
-					if (fraction.track != mainTrack) break;
+					if (fraction.track != mainTrack)
+						break;
 					if (prev != Reaction.CLEAR_NEW || prevClear.length > 0) {
 						bytes.write(0x0A);
 					}
 					writeTrimmed(bytes, fraction.sylineBytes);
 					break;
 				case NEWLINE_AFTER:
-					if (fraction.track != mainTrack) break;
+					if (fraction.track != mainTrack)
+						break;
 					writeTrimmed(bytes, fraction.sylineBytes);
 					bytes.write(0x0A);
 					break;
@@ -516,7 +511,8 @@ public class MidiText {
 				case CLEAR_OLD:
 					bytes.write(0x0A);
 					bytes.write(0x0A);
-					if (fraction.track != mainTrack) break;
+					if (fraction.track != mainTrack)
+						break;
 					writeTrimmed(bytes, fraction.sylineBytes);
 					prevClear = fraction.sylineBytes;
 					break;
@@ -524,7 +520,7 @@ public class MidiText {
 					str.append("Title: ").append(decode(fraction.sylineBytes)).append("\n");
 					break;
 				case RIGHTS:
-					//str += "Lyrics copyright: "+decode(fraction.sylineBytes)+"\n";
+					// str += "Lyrics copyright: "+decode(fraction.sylineBytes)+"\n";
 					break;
 				case LANGUAGE:
 					str.append("Language: ").append(decode(fraction.sylineBytes)).append("\n");
@@ -566,33 +562,39 @@ public class MidiText {
 		for (TextFragment fraction : text) {
 			// Collect metadata
 			if (isMetadata(fraction.reaction)) {
-                metaLine = switch (fraction.reaction) {
-                    case TITLE -> "Title: " + decode(fraction.sylineBytes);
-                    case LANGUAGE -> "Language: " + decode(fraction.sylineBytes);
-                    case INFO -> "Info: " + decode(fraction.sylineBytes);
-                    case META_LINE -> fraction.prefix + decode(fraction.sylineBytes);
-                    case RIGHTS -> "Lyrics Copyrights: " + decode(fraction.sylineBytes);
+				metaLine = switch (fraction.reaction) {
+					case TITLE -> "Title: " + decode(fraction.sylineBytes);
+					case LANGUAGE -> "Language: " + decode(fraction.sylineBytes);
+					case INFO -> "Info: " + decode(fraction.sylineBytes);
+					case META_LINE -> fraction.prefix + decode(fraction.sylineBytes);
+					case RIGHTS -> "Lyrics Copyrights: " + decode(fraction.sylineBytes);
 					case WRITER -> "Writer: " + decode(fraction.sylineBytes);
 					case VERSION -> "Version: " + decode(fraction.sylineBytes);
 					default -> "";
-                };
+				};
 
 				if (!metaLine.isBlank() && !metaLinePrev.equals(metaLine)) {
-					//the prev check is for the same meta in different tracks
-					if (!metaBlock.isEmpty()) metaBlock.append("\n");
+					// the prev check is for the same meta in different tracks
+					if (!metaBlock.isEmpty())
+						metaBlock.append("\n");
 					metaBlock.append(metaLine);
 				}
 				metaLinePrev = metaLine;
 				continue;
 			}
 
-			if (fraction.track != mainTrack) continue;
+			if (fraction.track != mainTrack)
+				continue;
 
 			boolean isNewlineBefore = false;
 			boolean isNewlineAfter = false;
 			boolean processContent = false;
 
-			//System.out.println("Processing fragment: "+fraction.reaction+" bytes="+fraction.sylineBytes.length+" containsVisibleContent="+containsVisibleContent(fraction.sylineBytes, fraction.sylineBytes.length)+" content="+ MidiUtils.formatBytesHexOnly(fraction.sylineBytes)+" tick="+fraction.tick);
+			// System.out.println("Processing fragment: "+fraction.reaction+"
+			// bytes="+fraction.sylineBytes.length+"
+			// containsVisibleContent="+containsVisibleContent(fraction.sylineBytes,
+			// fraction.sylineBytes.length)+" content="+
+			// MidiUtils.formatBytesHexOnly(fraction.sylineBytes)+" tick="+fraction.tick);
 			switch (fraction.reaction) {
 				case LINE:
 				case FIRST:
@@ -628,12 +630,15 @@ public class MidiText {
 			// flush previous line (Allow empty lines)
 			if (isNewlineBefore) {
 				// If we are flushing, and lineBytes is empty, it's an empty line.
-				// We use the currentLineTick if set, otherwise the fraction's tick (for blank lines).
+				// We use the currentLineTick if set, otherwise the fraction's tick (for blank
+				// lines).
 				long tick = (currentLineTick != -1L) ? currentLineTick : fraction.tick;
 				long lastSyllableTick = (endTick != -1) ? endTick : tick;
 				String decodedLine = cleanSyllable(decodeWith(lineBytes.toByteArray()));
 				lines.add(new LyricLine(tick, decodedLine.trim(), lastSyllableTick));
-				//System.out.println("Newline before: "+decodedLine+" endTick="+endTick+" tick="+tick+" currentLineTick="+currentLineTick+" fraction.tick="+fraction.tick);
+				// System.out.println("Newline before: "+decodedLine+" endTick="+endTick+"
+				// tick="+tick+" currentLineTick="+currentLineTick+"
+				// fraction.tick="+fraction.tick);
 				lineBytes.reset();
 				endTick = -1L;
 				currentLineTick = -1L;
@@ -657,7 +662,8 @@ public class MidiText {
 			if (processContent && effectiveLength > 0) {
 				writeTrimmed(lineBytes, fraction.sylineBytes);
 
-				if (containsVisibleContent(fraction.sylineBytes, fraction.sylineBytes.length)) endTick = fraction.tick;
+				if (containsVisibleContent(fraction.sylineBytes, fraction.sylineBytes.length))
+					endTick = fraction.tick;
 			}
 
 			// Flush immediately if newline is AFTER
@@ -665,7 +671,9 @@ public class MidiText {
 				long tick = (currentLineTick != -1L) ? currentLineTick : fraction.tick;
 				long lastSyllableTick = (endTick != -1L) ? endTick : tick;
 				String decodedLine = cleanSyllable(decodeWith(lineBytes.toByteArray()));
-				//System.out.println("Newline after: "+decodedLine+" endTick="+endTick+" tick="+tick+" currentLineTick="+currentLineTick+" fraction.tick="+fraction.tick);
+				// System.out.println("Newline after: "+decodedLine+" endTick="+endTick+"
+				// tick="+tick+" currentLineTick="+currentLineTick+"
+				// fraction.tick="+fraction.tick);
 				lines.add(new LyricLine(tick, decodedLine.trim(), lastSyllableTick));
 
 				lineBytes.reset();
@@ -680,14 +688,15 @@ public class MidiText {
 		if (lineBytes.size() > 0) {
 			String decodedLine = cleanSyllable(decodeWith(lineBytes.toByteArray()));
 			long lastSyllableTick = (endTick != -1L) ? endTick : Math.max(0L, currentLineTick);
-			// Allow last line to be added even if effectively empty, to match the file structure
+			// Allow last line to be added even if effectively empty, to match the file
+			// structure
 			lines.add(new LyricLine(Math.max(0L, currentLineTick), decodedLine.trim(), lastSyllableTick));
 		}
 
 		if (!metaBlock.isEmpty()) {
 			lines.addFirst(new LyricLine(0L, metaBlock.toString(), 0L));
 		} else {
-			//make sure there always is a meta-block in the first slot.
+			// make sure there always is a meta-block in the first slot.
 			lines.addFirst(new LyricLine(0L, "", 0L));
 		}
 
@@ -700,7 +709,8 @@ public class MidiText {
 	}
 
 	private boolean containsVisibleContent(byte[] bytes, int length) {
-		if (bytes == null || length <= 0) return false;
+		if (bytes == null || length <= 0)
+			return false;
 		for (int i = 0; i < length; i++) {
 			// Check for chars > 32 (Space).
 			// This filters out spaces, nulls, tabs, and newlines.
@@ -715,29 +725,31 @@ public class MidiText {
 	 * Call me after decoding syllable/line
 	 *
 	 * Will remove some chord symbols.
-     */
+	 */
 	private String cleanSyllable(String str) {
 		str = str.replace("STARTAKKORD", "");
-		str = str.replace("|C:|", "");//chorus start
-		str = str.replace("|:C|", "");//chorus end (normally in later syllable than start)
+		str = str.replace("|C:|", "");// chorus start
+		str = str.replace("|:C|", "");// chorus end (normally in later syllable than start)
 
 		return str;
 	}
-	
+
 	private static void writeTrimmed(ByteArrayOutputStream out, byte[] data) {
-	    int end = data.length;
-	    while (end > 0 && data[end - 1] == (byte)0x00) {
-	        end--;
-	    }
-	    out.write(data, 0, end);
+		int end = data.length;
+		while (end > 0 && data[end - 1] == (byte) 0x00) {
+			end--;
+		}
+		out.write(data, 0, end);
 	}
 
 	private boolean isChord(String text) {
-		if (text == null) return false;
+		if (text == null)
+			return false;
 
 		int originalLength = text.length();
 		String trimmed = text.trim();
-		if (trimmed.isEmpty()) return false;
+		if (trimmed.isEmpty())
+			return false;
 
 		// Calculate Padding
 		// We don't return true immediately. We just note that it looks suspicious.
@@ -771,18 +783,19 @@ public class MidiText {
 		long tick;
 		Format format;
 		Source source;
-		String syline = "";//  syllable/line
+		String syline = "";// syllable/line
 		int track;
 		Reaction reaction;
-		
+
 		String prefix = "";
 		byte[] sylineBytes = {};
-		
+
 		@Override
 		public String toString() {
-			return format+": "+reaction+" ("+source+") '"+syline+"' in track "+track+" tick="+tick+(sylineBytes==null?"":(" hex:"+MidiUtils.formatBytesHexOnly(sylineBytes)));
+			return format + ": " + reaction + " (" + source + ") '" + syline + "' in track " + track + " tick=" + tick
+					+ (sylineBytes == null ? "" : (" hex:" + MidiUtils.formatBytesHexOnly(sylineBytes)));
 		}
-		
+
 		public enum Reaction {
 			// the order matters
 			TITLE,
@@ -791,43 +804,47 @@ public class MidiText {
 			INFO,
 			VERSION,
 			WRITER,
-			FIRST,// first full line
+			FIRST, // first full line
 			SECOND,
 			THIRD,
 			FOURTH,
-			
-			LINE,// full line
-			CLEAR_OLD,//clear screen
-			NEWLINE_OLD,// newline before syllable
+
+			LINE, // full line
+			CLEAR_OLD, // clear screen
+			NEWLINE_OLD, // newline before syllable
 			SYLLABLE,
-			NEWLINE_AFTER,// newline after syllable
-			CLEAR_NEW,//clear screen
-			NEWLINE_NEW,// newline
+			NEWLINE_AFTER, // newline after syllable
+			CLEAR_NEW, // clear screen
+			NEWLINE_NEW, // newline
 			CHORD,
 			SYNC // highlight next full line
 			, META_LINE // M-LIVE
-			
-			// in modern Tune1000 kar, newline is sometimes at same tick as syllable, meaning syllable first, then newline.
-			// in older Soft Karaoke kar, newline is sometimes at same tick as syllable, meaning newline first, then syllable.
+
+			// in modern Tune1000 kar, newline is sometimes at same tick as syllable,
+			// meaning syllable first, then newline.
+			// in older Soft Karaoke kar, newline is sometimes at same tick as syllable,
+			// meaning newline first, then syllable.
 		}
+
 		public enum Source {
 			// which kind of midi event that was source of this TextFragment.
 			SYSEX,
 			LYRIC,
 			TEXT,
-			MARK, 
+			MARK,
 			CUE,
 			MLIVE
 		}
+
 		public enum Format {
 			SOFT_KARAOKE,
-			TUNE1000,// kinda version 2 of soft karaoke
-			SOLTON,// very simple
-			MIDISOFT,// sysex based
-			KARAKAN,// variation of Tune1000
+			TUNE1000, // kinda version 2 of soft karaoke
+			SOLTON, // very simple
+			MIDISOFT, // sysex based
+			KARAKAN, // variation of Tune1000
 			UNKNOWN// does not adhere to any standard
 		}
-		
+
 		@Override
 		public int compareTo(TextFragment o) {
 			// to be added to treeset compareTo() must never return 0
@@ -855,10 +872,10 @@ public class MidiText {
 			}
 			return c;
 		}
-		
+
 		@Override
 		public boolean equals(Object o) {
-			return false;			
+			return false;
 		}
 	}
 }

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -564,8 +564,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									try {
 										backupTimeSignature = new TimeSignature(m, true);
 									} catch (InvalidMidiDataException e2) {
-										String message = fileName + ": Ignoring illegal time signature.";
-										logMessage(Level.WARNING, message);
+						// Ignore the illegal time signature
 									}
 								}
 							}

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -2,6 +2,7 @@ package com.digero.maestro.midi;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MetaMessage;
@@ -127,18 +128,22 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 							switch (shortMsg.getData1()) {
 								case REGISTERED_PARAMETER_NUMBER_MSB:
 									int valueMSB = shortMsg.getData2();
-									if (valueMSB > 127)
-										log.warning("RPN MSB out of bounds and will be ignored: port=" + port + ", ch="
-												+ ch + ", tick=" + tick + ", value=" + valueMSB);
-									else
+									if (valueMSB > 127) {
+										String message = "RPN MSB out of bounds and will be ignored: port=" + port
+												+ ", ch=" + ch + ", tick=" + tick
+												+ ", value=" + valueMSB;
+										logMessage(Level.WARNING, message);
+									} else
 										rpnMSBMap.put(port, ch, tick, jj, valueMSB);
 									break;
 								case REGISTERED_PARAMETER_NUMBER_LSB:
 									int valueLSB = shortMsg.getData2();
-									if (valueLSB > 127)
-										log.warning("RPN LSB out of bounds and will be ignored: port=" + port + ", ch="
-												+ ch + ", tick=" + tick + ", value=" + valueLSB);
-									else
+									if (valueLSB > 127) {
+										String message = "RPN LSB out of bounds and will be ignored: port=" + port
+												+ ", ch=" + ch + ", tick=" + tick
+												+ ", value=" + valueLSB;
+										logMessage(Level.WARNING, message);
+									} else
 										rpnLSBMap.put(port, ch, tick, jj, valueLSB);
 									break;
 								case RESET_ALL_CONTROLLERS:
@@ -172,9 +177,11 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										if (usingNewMidiLayout > 0)
 											expression.put(port, ch, tick, DEFAULT_EXPRESSION);
 
-										if (changingStuff)
-											log.warning(fileName + ": Resetting all controllers on channel " + ch
-													+ ", tick " + tick + str);
+										if (changingStuff) {
+											String message = "Resetting all controllers on channel " + ch + ", tick "
+													+ tick + str;
+											logMessage(Level.WARNING, message);
+										}
 									}
 									break;
 							}
@@ -218,9 +225,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										mapPatch.put(port, ch, tick, 0);
 									}
 								}
-								log.warning(
-										fileName + ": Resetting everything, tick " + tick + " GM=" + isResetGM + " XG="
-												+ isResetXG + " GS=" + isResetGS + " GM2=" + isResetGM2);
+								String message = fileName + ": Resetting everything, tick " + tick + " GM=" + isResetGM
+										+ " XG=" + isResetXG + " GS=" + isResetGS + " GM2=" + isResetGM2;
+								logMessage(Level.WARNING, message);
 							}
 						}
 					}
@@ -277,8 +284,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 							}
 						} else if (cmd == ShortMessage.PROGRAM_CHANGE) {
 							if (shortMsg.getData1() > 127) {
-								log.warning(fileName + "; Channel " + ch + ": Ignoring program change out of range: "
-										+ shortMsg.getData1());
+								String message = fileName + "; Channel " + ch
+										+ ": Ignoring program change out of range: "
+										+ shortMsg.getData1();
+								logMessage(Level.WARNING, message);
 								continue;
 							}
 							boolean allowGMPatchChange = true;
@@ -299,9 +308,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 
 							if (allowGMPatchChange) {
 								instruments.put(port, ch, tick, shortMsg.getData1());
-								log.fine("Instrument change on track " + iTrack + ", tick " + tick + ", instrument "
+								String str = "Instrument change on track " + iTrack + ", tick " + tick + ", instrument "
 										+ MidiInstrument.fromId(shortMsg.getData1()) + ", port " + portMap.get(iTrack)
-										+ ", channel " + ch);
+										+ ", channel " + ch;
+								logMessage(Level.FINE, str);
 							}
 							mapPatch.put(port, ch, tick, shortMsg.getData1());
 						} else if (cmd == ShortMessage.CONTROL_CHANGE) {
@@ -319,9 +329,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 								case DATA_ENTRY_COARSE:
 									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
 										if (shortMsg.getData2() > 127) {
-											log.warning(fileName + "; Channel " + ch + " Port " + port
+											String message = fileName + "; Channel " + ch + " Port " + port
 													+ ": Clamping coarse pitch bend wheel range out of bounds: "
-													+ shortMsg.getData2() + " semitones");
+													+ shortMsg.getData2() + " semitones";
+											logMessage(Level.WARNING, message);
 										}
 										pitchBendRangeCoarse.put(port, ch, tick, jj,
 												Math.clamp(shortMsg.getData2(), 0, 127));
@@ -330,9 +341,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 								case DATA_ENTRY_FINE:
 									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
 										if (shortMsg.getData2() > 99) {
-											log.info(fileName + "; Channel " + ch + " Port " + port
+											String message = fileName + "; Channel " + ch + " Port " + port
 													+ ": Clamping fine pitch bend wheel range out of bounds: "
-													+ shortMsg.getData2() + " cents.");
+													+ shortMsg.getData2() + " cents.";
+											logMessage(Level.WARNING, message);
 										}
 										pitchBendRangeFine.put(port, ch, tick, jj,
 												Math.clamp(shortMsg.getData2(), 0, 99));
@@ -361,7 +373,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 												currentFine = 99;
 											}
 										}
-										log.fine("DATA_BUTTON_INCREMENT for pitch bend detected.");
+										String message = fileName + "; Channel " + ch + " Port " + port
+												+ ": DATA_BUTTON_INCREMENT for pitch bend detected.";
+										logMessage(Level.FINE, message);
 										pitchBendRangeFine.put(port, ch, tick, jj, currentFine);
 									}
 									break;
@@ -385,7 +399,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										}
 
 										pitchBendRangeFine.put(port, ch, tick, jj, currentFine2);
-										log.fine("DATA_BUTTON_DECREMENT for pitch bend detected.");
+										String message = fileName + "; Channel " + ch + " Port " + port
+												+ ": DATA_BUTTON_DECREMENT for pitch bend detected.";
+										logMessage(Level.FINE, message);
 									}
 									break;
 								case PAN_CONTROL:
@@ -393,8 +409,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									break;
 								case BANK_SELECT_MSB:
 									if (shortMsg.getData2() > 127) {
-										log.warning(fileName + "; Channel " + ch
-												+ ": Ignoring MSB bank address out of range: " + shortMsg.getData2());
+										String message = fileName + "; Channel " + ch
+												+ ": Ignoring MSB bank address out of range: " + shortMsg.getData2();
+										logMessage(Level.WARNING, message);
 										continue;
 									}
 
@@ -408,7 +425,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										} else if (ch == DRUM_CHANNEL && MidiStandard.XG == standard
 												&& shortMsg.getData2() != 126
 												&& shortMsg.getData2() != 127) {
-											log.finer("XG Drum Part Protect Mode prevented bank select MSB.");
+											String message = fileName + "; Channel " + ch
+													+ ": XG Drum Part Protect Mode prevented bank select MSB.";
+											logMessage(Level.FINER, message);
 										}
 										// if(ch==DRUM_CHANNEL) System.err.println("Bank select MSB "+m.getData2()+"
 										// "+tick);
@@ -420,8 +439,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 
 										if (isXGDrumChannel && shortMsg.getData2() != 126
 												&& shortMsg.getData2() != 127) {
-											log.finer("XG Drum Part Protect Mode prevented bank select MSB on port "
-													+ port + " channel " + ch);
+											String message = fileName + "; Channel " + ch + " Port " + port
+													+ ": XG Drum Part Protect Mode prevented bank select MSB.";
+											logMessage(Level.FINER, message);
 										} else {
 											mapMSB.put(port, ch, tick, shortMsg.getData2());
 										}
@@ -429,8 +449,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									break;
 								case BANK_SELECT_LSB:
 									if (shortMsg.getData2() > 127) {
-										log.warning(fileName + "; Channel " + ch
-												+ ": Ignoring LSB bank address out of range: " + shortMsg.getData2());
+										String message = fileName + "; Channel " + ch
+												+ ": Ignoring LSB bank address out of range: " + shortMsg.getData2();
+										logMessage(Level.WARNING, message);
 										continue;
 									}
 									mapLSB.put(port, ch, tick, shortMsg.getData2());
@@ -442,8 +463,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 							int value1 = shortMsg.getData1();
 							int value2 = shortMsg.getData2();
 							if (value1 > 127 || value2 > 127) {
-								log.warning(fileName + "; Channel " + ch + ": Clamping pitch bend out of range: "
-										+ value1 + "," + value2);
+								String message = fileName + "; Channel " + ch + ": Clamping pitch bend out of range: "
+										+ value1 + "," + value2;
+								logMessage(Level.WARNING, message);
 							}
 							value1 = Math.clamp(value1, 0, 127);
 							value2 = Math.clamp(value2, 0, 127);
@@ -495,8 +517,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 
 								tempo.put(tick, new TempoEvent(tempoRaw, tick, 0L));// micros is added later
 								if (iTrack != 0) {
-									log.fine("Track " + iTrack + " has tempo message in non-first track. "
-											+ MidiUtils.convertTempo(tempoRaw) + " BPM, tick " + tick);
+									String message = fileName + ": Track " + iTrack
+											+ " has tempo message in non-first track. "
+											+ MidiUtils.convertTempo(tempoRaw) + " BPM, tick " + tick;
+									logMessage(Level.FINE, message);
 									// we move the tempo event to track 0 so the playback
 									// matches our internal tempos.
 									// This means that if the user expands the midi
@@ -513,10 +537,14 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 								}
 							}
 						} else {
-							if (tempoRaw == 0)
-								log.warning("MIDI has tempo message of zero MPQ! Ignoring it..");
-							if (tempoRaw < 0)
-								log.warning("MIDI has tempo message of negative MPQ! Ignoring it..");
+							if (tempoRaw == 0) {
+								String message = fileName + ": MIDI has tempo message of zero MPQ! Ignoring it..";
+								logMessage(Level.WARNING, message);
+							}
+							if (tempoRaw < 0) {
+								String message = fileName + ": MIDI has tempo message of negative MPQ! Ignoring it..";
+								logMessage(Level.WARNING, message);
+							}
 							track.remove(evt);
 							sz--;
 							j--;
@@ -536,7 +564,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									try {
 										backupTimeSignature = new TimeSignature(m, true);
 									} catch (InvalidMidiDataException e2) {
-										// Ignore the illegal time signature
+										String message = fileName + ": Ignoring illegal time signature.";
+										logMessage(Level.WARNING, message);
 									}
 								}
 							}
@@ -551,14 +580,16 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 						} else if (!ignoreMidiText && type == META_M_LIVE && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_M_LIVE, iTrack);
 						} else if (m.getType() == META_COPYRIGHT && tick == 0L && iTrack == 0) {
-							log.finer("\n(c): " + MidiUtils.formatBytes(data));
+							String message = fileName + ": (c): " + MidiUtils.formatBytes(data);
+							logMessage(Level.FINER, message);
 							String tmp = "";
 							if (!ignoreMidiText)
 								tmp = MidiUtils.decodeMidiText(data).trim();
 
 							if (!tmp.isEmpty()) {
 								copyright = tmp;
-								log.info("MIDI copyright: " + tmp);
+								message = fileName + ": MIDI copyright: " + tmp;
+								logMessage(Level.INFO, message);
 							}
 						}
 					}
@@ -687,16 +718,30 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 
 		songLengthTicks = lastTick;
 
-		if (!ignoreMidiText && standard != MidiStandard.ABC)
-			log.info("Lyrics stats: " + midiText.getTextStats());
+		if (!ignoreMidiText && standard != MidiStandard.ABC) {
+			String message = fileName + ": Lyrics stats: " + midiText.getTextStats();
+			logMessage(Level.INFO, message);
+		}
+	}
+
+	private void logMessage(Level warning, String message) {
+		message = message
+				.replace('\r', ' ')
+				.replace('\n', ' ')
+				.replace('\t', ' ')
+				.replaceAll("\\p{Cntrl}", "")
+				.replaceAll(" +", " ")
+				.trim();
+		log.log(warning, message);
 	}
 
 	private int getRPN(int port, int channel, long tick, long index) {
 		int msb = rpnMSBMap.get(port, channel, tick, index);
 		int lsb = rpnLSBMap.get(port, channel, tick, index);
 		if (msb != DEFAULT_RPN_NULL && lsb == DEFAULT_RPN_NULL) {// && rpnLSBMap.getEntries(channel,0L, tick).isEmpty()
-			log.severe(fileName + ": Channel " + channel
-					+ ", RPN being utilized while LSB is default (NULL)! Using effective value of 0 LSB.");
+			String message = fileName + ": Channel " + channel
+					+ ", RPN being utilized while LSB is default (NULL)! Using effective value of 0 LSB.";
+			logMessage(Level.SEVERE, message);
 			lsb = 0;
 		}
 		return (msb << 7) | lsb;

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -59,7 +59,6 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	private final Map<Integer, ArrayList<TreeMap<Long, Boolean>>> mmaDrumSwitches;
 	public boolean hasPorts = false;
 	private String copyright = "";
-	private final boolean ignoreZeroChannelVolume;
 	private final MidiText midiText;
 	private boolean tempoInHigherTracks = false;
 	private String fileName = "";
@@ -87,8 +86,6 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		this.yamahaDrumChannels = yamahaDrumChannels;
 		this.yamahaDrumSwitches = yamahaDrumSwitches;
 		this.mmaDrumSwitches = mmaDrumSwitches;
-
-		this.ignoreZeroChannelVolume = ignoreZeroChannelVolume;
 
 		brandDrumBanks = new DrumBankType[song.getTracks().length];
 
@@ -147,8 +144,6 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 								case RESET_ALL_CONTROLLERS:
 									if (tick > 0L) {
 										String str = "";
-										int rl = rpnLSBMap.get(port, ch, tick, jj);
-										int rm = rpnMSBMap.get(port, ch, tick, jj);
 										int p = (usingNewMidiLayout >= 1) ? port : 0;
 										int ex = expression.get(p, ch, tick);
 										boolean changingStuff = (usingNewMidiLayout > 0 && ex != 127);// too much hassle

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -32,7 +32,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	private final int primaryTempoMPQ;
 	private final TimeSignature timeSignature;
 	private final NavigableMap<Long, TempoEvent> tempo = new TreeMap<>();
-    private final NavigableMap<Long, TempoEvent> tempoByMicros = new TreeMap<>();
+	private final NavigableMap<Long, TempoEvent> tempoByMicros = new TreeMap<>();
 
 	private final long songLengthTicks;
 	private static final int NO_RESULT = -250;
@@ -40,7 +40,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	private final MapByChannelPort instruments = new MapByChannelPort(DEFAULT_INSTRUMENT);
 	private final MapByChannelPort channelVolume = new MapByChannelPort(DEFAULT_CHANNEL_VOLUME);
 	private final MapByChannelPort expression = new MapByChannelPort(DEFAULT_EXPRESSION);
-	private final MapByChannelPortMsg pitchBendRangeCoarse = new MapByChannelPortMsg(DEFAULT_PITCH_BEND_RANGE_SEMITONES);
+	private final MapByChannelPortMsg pitchBendRangeCoarse = new MapByChannelPortMsg(
+			DEFAULT_PITCH_BEND_RANGE_SEMITONES);
 	private final MapByChannelPortMsg pitchBendRangeFine = new MapByChannelPortMsg(DEFAULT_PITCH_BEND_RANGE_CENTS);
 	private final MapByChannelPort bendMap;
 	private final MapByChannelPortMsg rpnLSBMap = new MapByChannelPortMsg(DEFAULT_RPN_NULL);
@@ -60,15 +61,15 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	private String copyright = "";
 	private final boolean ignoreZeroChannelVolume;
 	private final MidiText midiText;
-    private boolean tempoInHigherTracks = false;
+	private boolean tempoInHigherTracks = false;
 	private String fileName = "";
 	private final int usingNewMidiLayout;
 
 	public SequenceDataCache(Sequence song, MidiStandard standard,
-							 Map<Integer, ArrayList<Boolean>> rolandDrumChannels,
-							 Map<Integer, ArrayList<TreeMap<Long, Boolean>>> yamahaDrumSwitches,
-							 Map<Integer, ArrayList<Boolean>> yamahaDrumChannels,
-			                 Map<Integer, ArrayList<TreeMap<Long, Boolean>>> mmaDrumSwitches, SortedMap<Integer, Integer> portMap,
+			Map<Integer, ArrayList<Boolean>> rolandDrumChannels,
+			Map<Integer, ArrayList<TreeMap<Long, Boolean>>> yamahaDrumSwitches,
+			Map<Integer, ArrayList<Boolean>> yamahaDrumChannels,
+			Map<Integer, ArrayList<TreeMap<Long, Boolean>>> mmaDrumSwitches, SortedMap<Integer, Integer> portMap,
 			boolean onlyFirstTrackTempos, boolean ignoreZeroChannelVolume, boolean ignoreMidiText,
 			String fileName, int usingNewMidiLayout, boolean hasPorts) {
 
@@ -76,7 +77,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		this.usingNewMidiLayout = usingNewMidiLayout;
 		this.portMap = portMap;
 
-        // This is total accumulated duration in micros of each tempo used in the song
+		// This is total accumulated duration in micros of each tempo used in the song
 		Map<Integer, Long> tempoLengths = new HashMap<>();// MPQ -> micros
 
 		this.hasPorts = hasPorts;
@@ -97,11 +98,13 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		divisionType = song.getDivisionType();
 		tickResolution = song.getResolution();
 
-		midiText = new MidiText(this);
-		
+		midiText = new MidiText();
+
 		/*
-		 * We need to be able to know which tracks have drum notes. We also need to know what instrument voices are used
-		 * in each track, so we build maps of voice changes that TrackInfo later can use to build strings of instruments
+		 * We need to be able to know which tracks have drum notes. We also need to know
+		 * what instrument voices are used
+		 * in each track, so we build maps of voice changes that TrackInfo later can use
+		 * to build strings of instruments
 		 * for each track.
 		 * 
 		 * This among other things we will find out by iterating through all MidiEvents.
@@ -127,13 +130,19 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 							switch (shortMsg.getData1()) {
 								case REGISTERED_PARAMETER_NUMBER_MSB:
 									int valueMSB = shortMsg.getData2();
-									if (valueMSB > 127) log.warning("RPN MSB out of bounds and will be ignored: port=" + port + ", ch=" + ch + ", tick=" + tick + ", value=" + valueMSB);
-									else rpnMSBMap.put(port, ch, tick, jj, valueMSB);
+									if (valueMSB > 127)
+										log.warning("RPN MSB out of bounds and will be ignored: port=" + port + ", ch="
+												+ ch + ", tick=" + tick + ", value=" + valueMSB);
+									else
+										rpnMSBMap.put(port, ch, tick, jj, valueMSB);
 									break;
 								case REGISTERED_PARAMETER_NUMBER_LSB:
 									int valueLSB = shortMsg.getData2();
-									if (valueLSB > 127) log.warning("RPN LSB out of bounds and will be ignored: port=" + port + ", ch=" + ch + ", tick=" + tick + ", value=" + valueLSB);
-									else rpnLSBMap.put(port, ch, tick, jj, valueLSB);
+									if (valueLSB > 127)
+										log.warning("RPN LSB out of bounds and will be ignored: port=" + port + ", ch="
+												+ ch + ", tick=" + tick + ", value=" + valueLSB);
+									else
+										rpnLSBMap.put(port, ch, tick, jj, valueLSB);
 									break;
 								case RESET_ALL_CONTROLLERS:
 									if (tick > 0L) {
@@ -142,59 +151,82 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										int rm = rpnMSBMap.get(port, ch, tick, jj);
 										int p = (usingNewMidiLayout >= 1) ? port : 0;
 										int ex = expression.get(p, ch, tick);
-										boolean changingStuff = (usingNewMidiLayout > 0 && ex != 127);// too much hassle to detect if bend wheel was active. rl != 127 || rm != 127 ||
+										boolean changingStuff = (usingNewMidiLayout > 0 && ex != 127);// too much hassle
+																										// to detect if
+																										// bend wheel
+																										// was active.
+																										// rl != 127 ||
+																										// rm != 127 ||
 										if (changingStuff) {
-											//str += "\n rpn lsb " + rl + " -> " + DEFAULT_RPN_NULL;
-											//str += "\n rpn msb " + rm + " -> " + DEFAULT_RPN_NULL;
-											if (usingNewMidiLayout > 0) str += "\n expr " + ex + " -> " + DEFAULT_EXPRESSION;
-											//str += "\n pitch wheel -> 0%";
+											// str += "\n rpn lsb " + rl + " -> " + DEFAULT_RPN_NULL;
+											// str += "\n rpn msb " + rm + " -> " + DEFAULT_RPN_NULL;
+											if (usingNewMidiLayout > 0)
+												str += "\n expr " + ex + " -> " + DEFAULT_EXPRESSION;
+											// str += "\n pitch wheel -> 0%";
 										}
 
-										//this will remove some pitch bending changes from some songs, but it's the right thing to do as per specs:
-										//rpnLSBMap.putIfAbsent(port, ch, tick, DEFAULT_RPN_NULL);
-										//rpnMSBMap.putIfAbsent(port, ch, tick, DEFAULT_RPN_NULL);
+										// this will remove some pitch bending changes from some songs, but it's the
+										// right thing to do as per specs:
+										// rpnLSBMap.putIfAbsent(port, ch, tick, DEFAULT_RPN_NULL);
+										// rpnMSBMap.putIfAbsent(port, ch, tick, DEFAULT_RPN_NULL);
 
-										// this should per spec be enabled, but it will break many badly made songs to reset pitch wheel.
-										//pitchWheelMap.add(new Quad<>(port, ch, tick, 0.0d));
+										// this should per spec be enabled, but it will break many badly made songs to
+										// reset pitch wheel.
+										// pitchWheelMap.add(new Quad<>(port, ch, tick, 0.0d));
 
-										if (usingNewMidiLayout > 0) expression.put(port, ch, tick, DEFAULT_EXPRESSION);
+										if (usingNewMidiLayout > 0)
+											expression.put(port, ch, tick, DEFAULT_EXPRESSION);
 
-										if (changingStuff) log.warning(fileName + ": Resetting all controllers on channel " + ch + ", tick " + tick + str);
+										if (changingStuff)
+											log.warning(fileName + ": Resetting all controllers on channel " + ch
+													+ ", tick " + tick + str);
 									}
 									break;
 							}
 						}
-					} else if (specCompliant && tick > 0L && msg instanceof SysexMessage sysex) {
-						byte[] smsg = sysex.getMessage();
-						boolean isResetGM = false;
-						boolean isResetGM2 = false;
-						boolean isResetXG = false;
-						boolean isResetGS = false;
-						if ((isResetGM = MidiUtils.isResetGM(smsg)) || (isResetGS = MidiUtils.isResetGS(smsg, true))
-								|| (isResetXG = MidiUtils.isResetXG(smsg)) || (isResetGM2 = MidiUtils.isResetGM2(smsg))) {
 
-							// TODO: This will break backwards compatibility for sure :(
-							//       Therefore the specCompliant bool stops it from happening.
-							//       In future versions, this behavior may be configurable.
-							for (int ch = 0; ch < CHANNEL_COUNT_ABC; ch++) {
-								rpnLSBMap.put(port, ch, tick, jj, DEFAULT_RPN_NULL);
-								rpnMSBMap.put(port, ch, tick, jj, DEFAULT_RPN_NULL);
-								expression.put(port, ch, tick, DEFAULT_EXPRESSION);
-								channelVolume.put(port, ch, tick, DEFAULT_CHANNEL_VOLUME);
-								panMap.put(port, ch, tick, PAN_CENTER);
-								pitchWheelMap.add(new Quint<>(port, ch, tick, (long)jj,0.0d));
-								pitchBendRangeCoarse.put(port, ch, tick, jj, DEFAULT_PITCH_BEND_RANGE_SEMITONES);
-								pitchBendRangeFine.put(port, ch, tick, jj, DEFAULT_PITCH_BEND_RANGE_CENTS);
-								if (MidiStandard.GM == standard && isResetGM) {
-									// This has issues. What if there is a GM reset in the middle
-									// of a GS file? This will reset the patch, which is not ideal.
-									// This code should probably never be run, even though its spec compliant.
-									mapMSB.put(port, ch, tick, 0);
-									mapLSB.put(port, ch, tick, 0);
-									mapPatch.put(port, ch, tick, 0);
+					} else if (specCompliant) {
+						/*
+						 * This else if was (specCompliant && tick > 0L && msg instanceof
+						 * SysexMessage sysex) beforehand and that resulted in dead code.
+						 * specCompliant is false, so this block will never run.
+						 * was left here in case we want to enable it later.
+						 */
+						if (tick > 0L && msg instanceof SysexMessage sysex) {
+							byte[] smsg = sysex.getMessage();
+							boolean isResetGM = false;
+							boolean isResetGM2 = false;
+							boolean isResetXG = false;
+							boolean isResetGS = false;
+							if ((isResetGM = MidiUtils.isResetGM(smsg)) || (isResetGS = MidiUtils.isResetGS(smsg, true))
+									|| (isResetXG = MidiUtils.isResetXG(smsg))
+									|| (isResetGM2 = MidiUtils.isResetGM2(smsg))) {
+
+								// TODO: This will break backwards compatibility for sure :(
+								// Therefore the specCompliant bool stops it from happening.
+								// In future versions, this behavior may be configurable.
+								for (int ch = 0; ch < CHANNEL_COUNT_ABC; ch++) {
+									rpnLSBMap.put(port, ch, tick, jj, DEFAULT_RPN_NULL);
+									rpnMSBMap.put(port, ch, tick, jj, DEFAULT_RPN_NULL);
+									expression.put(port, ch, tick, DEFAULT_EXPRESSION);
+									channelVolume.put(port, ch, tick, DEFAULT_CHANNEL_VOLUME);
+									panMap.put(port, ch, tick, PAN_CENTER);
+									pitchWheelMap.add(new Quint<>(port, ch, tick, (long) jj, 0.0d));
+									pitchBendRangeCoarse.put(port, ch, tick, jj, DEFAULT_PITCH_BEND_RANGE_SEMITONES);
+									pitchBendRangeFine.put(port, ch, tick, jj, DEFAULT_PITCH_BEND_RANGE_CENTS);
+									if (MidiStandard.GM == standard && isResetGM) {
+										// This has issues. What if there is a GM reset in the middle
+										// of a GS file? This will reset the patch, which is not ideal.
+										// This code should probably never be run, even though its spec compliant.
+										mapMSB.put(port, ch, tick, 0);
+										mapLSB.put(port, ch, tick, 0);
+										mapPatch.put(port, ch, tick, 0);
+									}
 								}
+								log.warning(
+										fileName + ": Resetting everything, tick " + tick + " GM=" + isResetGM + " XG="
+												+ isResetXG + " GS=" + isResetGS + " GM2=" + isResetGM2);
 							}
-							log.warning(fileName+": Resetting everything, tick "+tick+" GM="+isResetGM+" XG="+isResetXG+" GS="+isResetGS+" GM2="+isResetGM2);
 						}
 					}
 				}
@@ -204,10 +236,13 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 				Track track = tracks[iTrack];
 				int port = portMap.get(iTrack);
 
-				// message index jj. It does not decrease when removing a tempo event from the track,
+				// message index jj. It does not decrease when removing a tempo event from the
+				// track,
 				// as it should be in sync with pass 1 jj.
-				// PS: These tempo movements to track 0 only works, cause fixuptracklength runs before trackInfo.
-				//     Consider in future to make a pre pass to pass 1 that does that movement. So jj is more stable downstream.
+				// PS: These tempo movements to track 0 only works, cause fixuptracklength runs
+				// before trackInfo.
+				// Consider in future to make a pre pass to pass 1 that does that movement. So
+				// jj is more stable downstream.
 				int jj = -1;
 				for (int j = 0, sz = track.size(); j < sz; j++) {
 					jj++;
@@ -218,7 +253,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 						lastTick = tick;
 
 					if (msg instanceof ShortMessage shortMsg) {
-                        int cmd = shortMsg.getCommand();
+						int cmd = shortMsg.getCommand();
 						int ch = shortMsg.getChannel();
 
 						if (cmd == ShortMessage.NOTE_ON) {
@@ -229,7 +264,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									}
 									break;
 								case XG:
-									if (yamahaDrumSwitches != null && getYamahaDrumAccurate(port, ch, tick)){
+									if (yamahaDrumSwitches != null && getYamahaDrumAccurate(port, ch, tick)) {
 										brandDrumBanks[iTrack] = DrumBankType.XG_DRUM;
 									}
 									break;
@@ -247,7 +282,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 							}
 						} else if (cmd == ShortMessage.PROGRAM_CHANGE) {
 							if (shortMsg.getData1() > 127) {
-								log.warning(fileName+"; Channel "+ch+": Ignoring program change out of range: "+shortMsg.getData1());
+								log.warning(fileName + "; Channel " + ch + ": Ignoring program change out of range: "
+										+ shortMsg.getData1());
 								continue;
 							}
 							boolean allowGMPatchChange = true;
@@ -256,10 +292,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									allowGMPatchChange = rolandDrumChannels == null || !getRolandDrum(port, ch);
 									break;
 								case XG:
-									allowGMPatchChange = !getYamahaDrumAccurate(port,ch,tick);
+									allowGMPatchChange = !getYamahaDrumAccurate(port, ch, tick);
 									break;
 								case GM2:
-									allowGMPatchChange = !getMmaDrumAccurate(port,ch,tick);
+									allowGMPatchChange = !getMmaDrumAccurate(port, ch, tick);
 									break;
 								default:
 									allowGMPatchChange = ch != DRUM_CHANNEL;
@@ -268,146 +304,165 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 
 							if (allowGMPatchChange) {
 								instruments.put(port, ch, tick, shortMsg.getData1());
-								log.fine("Instrument change on track "+iTrack+", tick "+tick+", instrument "+MidiInstrument.fromId(shortMsg.getData1())+ ", port "+portMap.get(iTrack)+", channel "+ch);
+								log.fine("Instrument change on track " + iTrack + ", tick " + tick + ", instrument "
+										+ MidiInstrument.fromId(shortMsg.getData1()) + ", port " + portMap.get(iTrack)
+										+ ", channel " + ch);
 							}
 							mapPatch.put(port, ch, tick, shortMsg.getData1());
 						} else if (cmd == ShortMessage.CONTROL_CHANGE) {
 							switch (shortMsg.getData1()) {
-							case CHANNEL_VOLUME_CONTROLLER_COARSE:
-								if (shortMsg.getData2() != 0 || !ignoreZeroChannelVolume) {
+								case CHANNEL_VOLUME_CONTROLLER_COARSE:
+									if (shortMsg.getData2() != 0 || !ignoreZeroChannelVolume) {
+										int p = (usingNewMidiLayout >= 1) ? port : 0;
+										channelVolume.put(p, ch, tick, Math.clamp(shortMsg.getData2(), 0, 127));
+									}
+									break;
+								case CHANNEL_EXPRESSION_CONTROLLER:
 									int p = (usingNewMidiLayout >= 1) ? port : 0;
-									channelVolume.put(p, ch, tick, Math.clamp(shortMsg.getData2(), 0, 127));
-								}
-								break;
-							case CHANNEL_EXPRESSION_CONTROLLER:
-								int p = (usingNewMidiLayout >= 1) ? port : 0;
-								expression.put(p, ch, tick, Math.clamp(shortMsg.getData2(), 0, 127));
-								break;
-							case DATA_ENTRY_COARSE:
-								if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
+									expression.put(p, ch, tick, Math.clamp(shortMsg.getData2(), 0, 127));
+									break;
+								case DATA_ENTRY_COARSE:
+									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
+										if (shortMsg.getData2() > 127) {
+											log.warning(fileName + "; Channel " + ch + " Port " + port
+													+ ": Clamping coarse pitch bend wheel range out of bounds: "
+													+ shortMsg.getData2() + " semitones");
+										}
+										pitchBendRangeCoarse.put(port, ch, tick, jj,
+												Math.clamp(shortMsg.getData2(), 0, 127));
+									}
+									break;
+								case DATA_ENTRY_FINE:
+									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
+										if (shortMsg.getData2() > 99) {
+											log.info(fileName + "; Channel " + ch + " Port " + port
+													+ ": Clamping fine pitch bend wheel range out of bounds: "
+													+ shortMsg.getData2() + " cents.");
+										}
+										pitchBendRangeFine.put(port, ch, tick, jj,
+												Math.clamp(shortMsg.getData2(), 0, 99));
+									}
+									break;
+								case DATA_BUTTON_INCREMENT:
+									// TODO: Since we do this track by track,
+									// data button changes spread across tracks can cause unintended values.
+									// Its an unlikely scenario, and I have never even seen a data button change
+									// being used in any midi.
+									// To fix it, can make a treemap of changes, and apply them after the loop.
+									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
+										int currentFine = pitchBendRangeFine.get(port, ch, tick, jj);
+										int currentCoarse = pitchBendRangeCoarse.get(port, ch, tick, jj);
+
+										currentFine++;
+
+										// RP-018: Wrap to next semitone when reaching 100 cents
+										if (currentFine >= 100) {
+											if (currentCoarse < 127) {
+												currentFine = 0;
+												currentCoarse++;
+												pitchBendRangeCoarse.put(port, ch, tick, jj, currentCoarse);
+											} else {
+												// Hard clamp at the absolute maximum (127 semitones, 99 cents)
+												currentFine = 99;
+											}
+										}
+										log.fine("DATA_BUTTON_INCREMENT for pitch bend detected.");
+										pitchBendRangeFine.put(port, ch, tick, jj, currentFine);
+									}
+									break;
+								case DATA_BUTTON_DECREMENT:
+									if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
+										int currentFine2 = pitchBendRangeFine.get(port, ch, tick, jj);
+										int currentCoarse2 = pitchBendRangeCoarse.get(port, ch, tick, jj);
+
+										currentFine2--;
+
+										// RP-018: Wrap to previous semitone when dropping below 0 cents
+										if (currentFine2 < 0) {
+											if (currentCoarse2 > 0) {
+												currentFine2 = 99;
+												currentCoarse2--;
+												pitchBendRangeCoarse.put(port, ch, tick, jj, currentCoarse2);
+											} else {
+												// Hard clamp at absolute minimum (0 semitones, 0 cents)
+												currentFine2 = 0;
+											}
+										}
+
+										pitchBendRangeFine.put(port, ch, tick, jj, currentFine2);
+										log.fine("DATA_BUTTON_DECREMENT for pitch bend detected.");
+									}
+									break;
+								case PAN_CONTROL:
+									panMap.put(port, ch, tick, Math.clamp(shortMsg.getData2(), 0, 127));
+									break;
+								case BANK_SELECT_MSB:
 									if (shortMsg.getData2() > 127) {
-										log.warning(fileName + "; Channel " + ch + " Port " + port + ": Clamping coarse pitch bend wheel range out of bounds: " + shortMsg.getData2()+" semitones");
+										log.warning(fileName + "; Channel " + ch
+												+ ": Ignoring MSB bank address out of range: " + shortMsg.getData2());
+										continue;
 									}
-									pitchBendRangeCoarse.put(port, ch, tick, jj, Math.clamp(shortMsg.getData2(), 0, 127));
-								}
-								break;
-							case DATA_ENTRY_FINE:
-								if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
-									if (shortMsg.getData2() > 99) {
-										log.info(fileName + "; Channel " + ch + " Port " + port + ": Clamping fine pitch bend wheel range out of bounds: " + shortMsg.getData2()+" cents.");
-									}
-									pitchBendRangeFine.put(port, ch, tick, jj, Math.clamp(shortMsg.getData2(), 0, 99));
-								}
-								break;
-							case DATA_BUTTON_INCREMENT:
-								// TODO: Since we do this track by track,
-								//       data button changes spread across tracks can cause unintended values.
-								//       Its an unlikely scenario, and I have never even seen a data button change being used in any midi.
-								//       To fix it, can make a treemap of changes, and apply them after the loop.
-								if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
-									int currentFine = pitchBendRangeFine.get(port, ch, tick, jj);
-									int currentCoarse = pitchBendRangeCoarse.get(port, ch, tick, jj);
 
-									currentFine++;
-
-									// RP-018: Wrap to next semitone when reaching 100 cents
-									if (currentFine >= 100) {
-										if (currentCoarse < 127) {
-											currentFine = 0;
-											currentCoarse++;
-											pitchBendRangeCoarse.put(port, ch, tick, jj, currentCoarse);
-										} else {
-											// Hard clamp at the absolute maximum (127 semitones, 99 cents)
-											currentFine = 99;
+									if (usingNewMidiLayout == 0) {
+										if (ch != DRUM_CHANNEL || MidiStandard.XG != standard
+												|| shortMsg.getData2() == 126
+												|| shortMsg.getData2() == 127) {
+											// Due to XG drum part protect mode being ON, drum channel 9 only can switch
+											// between MSB 126 & 127.
+											mapMSB.put(port, ch, tick, shortMsg.getData2());
+										} else if (ch == DRUM_CHANNEL && MidiStandard.XG == standard
+												&& shortMsg.getData2() != 126
+												&& shortMsg.getData2() != 127) {
+											log.finer("XG Drum Part Protect Mode prevented bank select MSB.");
 										}
-									}
-									log.fine("DATA_BUTTON_INCREMENT for pitch bend detected.");
-									pitchBendRangeFine.put(port, ch, tick, jj, currentFine);
-								}
-								break;
-							case DATA_BUTTON_DECREMENT:
-								if (getRPN(port, ch, tick, jj) == REGISTERED_PARAM_PITCH_BEND_RANGE) {
-									int currentFine2 = pitchBendRangeFine.get(port, ch, tick, jj);
-									int currentCoarse2 = pitchBendRangeCoarse.get(port, ch, tick, jj);
-
-									currentFine2--;
-
-									// RP-018: Wrap to previous semitone when dropping below 0 cents
-									if (currentFine2 < 0) {
-										if (currentCoarse2 > 0) {
-											currentFine2 = 99;
-											currentCoarse2--;
-											pitchBendRangeCoarse.put(port, ch, tick, jj, currentCoarse2);
-										} else {
-											// Hard clamp at absolute minimum (0 semitones, 0 cents)
-											currentFine2 = 0;
-										}
-									}
-
-									pitchBendRangeFine.put(port, ch, tick, jj, currentFine2);
-									log.fine("DATA_BUTTON_DECREMENT for pitch bend detected.");
-								}
-								break;
-							case PAN_CONTROL:
-								panMap.put(port, ch, tick, Math.clamp(shortMsg.getData2(),0,127));
-								break;
-							case BANK_SELECT_MSB:
-								if (shortMsg.getData2() > 127) {
-									log.warning(fileName+"; Channel "+ch+": Ignoring MSB bank address out of range: "+shortMsg.getData2());
-									continue;
-								}
-
-								if (usingNewMidiLayout == 0) {
-									if (ch != DRUM_CHANNEL || MidiStandard.XG != standard || shortMsg.getData2() == 126
-											|| shortMsg.getData2() == 127) {
-										// Due to XG drum part protect mode being ON, drum channel 9 only can switch
-										// between MSB 126 & 127.
-										mapMSB.put(port, ch, tick, shortMsg.getData2());
-									} else if (ch == DRUM_CHANNEL && MidiStandard.XG == standard && shortMsg.getData2() != 126
-											&& shortMsg.getData2() != 127) {
-										log.finer("XG Drum Part Protect Mode prevented bank select MSB.");
-									}
-									// if(ch==DRUM_CHANNEL) System.err.println("Bank select MSB "+m.getData2()+" "+tick);
-								} else {
-									boolean isXGDrumChannel = false;
-									if (MidiStandard.XG == standard && getYamahaDrumAccurate(port, ch, tick)) {
-										isXGDrumChannel = true;
-									}
-
-									if (isXGDrumChannel && shortMsg.getData2() != 126 && shortMsg.getData2() != 127) {
-										log.finer("XG Drum Part Protect Mode prevented bank select MSB on port " + port + " channel " + ch);
+										// if(ch==DRUM_CHANNEL) System.err.println("Bank select MSB "+m.getData2()+"
+										// "+tick);
 									} else {
-										mapMSB.put(port, ch, tick, shortMsg.getData2());
+										boolean isXGDrumChannel = false;
+										if (MidiStandard.XG == standard && getYamahaDrumAccurate(port, ch, tick)) {
+											isXGDrumChannel = true;
+										}
+
+										if (isXGDrumChannel && shortMsg.getData2() != 126
+												&& shortMsg.getData2() != 127) {
+											log.finer("XG Drum Part Protect Mode prevented bank select MSB on port "
+													+ port + " channel " + ch);
+										} else {
+											mapMSB.put(port, ch, tick, shortMsg.getData2());
+										}
 									}
-								}
-								break;
-							case BANK_SELECT_LSB:
-								if (shortMsg.getData2() > 127) {
-									log.warning(fileName+"; Channel "+ch+": Ignoring LSB bank address out of range: "+shortMsg.getData2());
-									continue;
-								}
-								mapLSB.put(port, ch, tick, shortMsg.getData2());
-								// if(ch==DRUM_CHANNEL) System.err.println("Bank select LSB "+m.getData2()+" "+tick);
-								break;
+									break;
+								case BANK_SELECT_LSB:
+									if (shortMsg.getData2() > 127) {
+										log.warning(fileName + "; Channel " + ch
+												+ ": Ignoring LSB bank address out of range: " + shortMsg.getData2());
+										continue;
+									}
+									mapLSB.put(port, ch, tick, shortMsg.getData2());
+									// if(ch==DRUM_CHANNEL) System.err.println("Bank select LSB "+m.getData2()+"
+									// "+tick);
+									break;
 							}
 						} else if (cmd == ShortMessage.PITCH_BEND) {
 							int value1 = shortMsg.getData1();
 							int value2 = shortMsg.getData2();
 							if (value1 > 127 || value2 > 127) {
-								log.warning(fileName+"; Channel "+ch+": Clamping pitch bend out of range: "+value1+","+value2);
+								log.warning(fileName + "; Channel " + ch + ": Clamping pitch bend out of range: "
+										+ value1 + "," + value2);
 							}
-							value1 = Math.clamp(value1,0,127);
-							value2 = Math.clamp(value2,0,127);
+							value1 = Math.clamp(value1, 0, 127);
+							value2 = Math.clamp(value2, 0, 127);
 							double pct = 2.0d * (((value1 | (value2 << 7)) / (double) (1 << 14)) - 0.5d);
-							pitchWheelMap.add(new Quint<>(port, ch, tick, (long)jj, pct));
+							pitchWheelMap.add(new Quint<>(port, ch, tick, (long) jj, pct));
 							// Notice we put in the bend even if its a repeat of same bend.
 							// Reason is that later on another track there might get put some
 							// bends in between them.
 						}
 					} else if (msg instanceof SysexMessage sysex) {
-                        byte[] message = sysex.getMessage();
+						byte[] message = sysex.getMessage();
 						if (message.length == 9 && (message[0] & 0xFF) == 0xF0 && (message[1] & 0xFF) == 0x43
-								&& (message[3] & 0xFF) == 0x4C // this check can change the listed instr, but that does not break back compat
+								&& (message[3] & 0xFF) == 0x4C // this check can change the listed instr, but that does
+																// not break back compat
 								&& (message[4] & 0xFF) == 0x08 && (message[8] & 0xFF) == 0xF7) {
 
 							if (MidiStandard.XG == standard) {
@@ -421,11 +476,13 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 										case "Patch" -> mapPatch.put(port, (int) message[5], tick, (int) message[7]);
 										case "LSB" -> mapLSB.put(port, (int) message[5], tick, (int) message[7]);
 									}
-								} else if (usingNewMidiLayout >= 1 && message[6] == 7 && message[5] < 16 && message[5] >= 0 && message[7] <= 5) {
+								} else if (usingNewMidiLayout >= 1 && message[6] == 7 && message[5] < 16
+										&& message[5] >= 0 && message[7] <= 5) {
 									// Reset the xg bank
 									boolean isDrum = (message[7] > 0);
 									mapMSB.put(port, (int) message[5], tick, isDrum ? 127 : 0);
-									mapPatch.put(port, (int) message[5], tick, 0); // Reset to Standard Kit / Grand Piano
+									mapPatch.put(port, (int) message[5], tick, 0); // Reset to Standard Kit / Grand
+																					// Piano
 								}
 							}
 						} else if (!ignoreMidiText) {
@@ -433,43 +490,49 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 						}
 					} else if (divisionType == Sequence.PPQ && MidiUtils.isMetaTempo(msg)) {
 
-                        int tempoRaw = MidiUtils.getTempoMPQ(msg);
-                        if (tempoRaw > 0) {
-                            if (iTrack > 0) tempoInHigherTracks = true;
+						int tempoRaw = MidiUtils.getTempoMPQ(msg);
+						if (tempoRaw > 0) {
+							if (iTrack > 0)
+								tempoInHigherTracks = true;
 
-                            if (!onlyFirstTrackTempos || iTrack == 0) {
-                                // Note that this is also done in the SequencerWrapper.TempoCacheSlow
+							if (!onlyFirstTrackTempos || iTrack == 0) {
+								// Note that this is also done in the SequencerWrapper.TempoCacheSlow
 
-                                tempo.put(tick, new TempoEvent(tempoRaw, tick, 0L));// micros is added later
-                                if (iTrack != 0) {
-                                    log.fine("Track " + iTrack + " has tempo message in non-first track. " + MidiUtils.convertTempo(tempoRaw) + " BPM, tick " + tick);
-                                    // we move the tempo event to track 0 so the playback
-                                    // matches our internal tempos.
-                                    // This means that if the user expands the midi
-                                    // the expanded midi will have all tempos in track 0 too.
-                                    // Not ideal but at least consistent.
+								tempo.put(tick, new TempoEvent(tempoRaw, tick, 0L));// micros is added later
+								if (iTrack != 0) {
+									log.fine("Track " + iTrack + " has tempo message in non-first track. "
+											+ MidiUtils.convertTempo(tempoRaw) + " BPM, tick " + tick);
+									// we move the tempo event to track 0 so the playback
+									// matches our internal tempos.
+									// This means that if the user expands the midi
+									// the expanded midi will have all tempos in track 0 too.
+									// Not ideal but at least consistent.
 
-                                    track.remove(evt);
-                                    sz--;
-                                    j--;
-                                    tracks[0].add(evt);
-                                    // if already tempo(s) at this tick in track 0, since this is added later will take
-                                    // precedence over the existing one(s) in track 0.
-                                }
-                            }
-                        } else {
-                            if (tempoRaw == 0) log.warning("MIDI has tempo message of zero MPQ! Ignoring it..");
-							if (tempoRaw < 0) log.warning("MIDI has tempo message of negative MPQ! Ignoring it..");
-                            track.remove(evt);
-                            sz--;
-                            j--;
-                        }
+									track.remove(evt);
+									sz--;
+									j--;
+									tracks[0].add(evt);
+									// if already tempo(s) at this tick in track 0, since this is added later will
+									// take
+									// precedence over the existing one(s) in track 0.
+								}
+							}
+						} else {
+							if (tempoRaw == 0)
+								log.warning("MIDI has tempo message of zero MPQ! Ignoring it..");
+							if (tempoRaw < 0)
+								log.warning("MIDI has tempo message of negative MPQ! Ignoring it..");
+							track.remove(evt);
+							sz--;
+							j--;
+						}
 					} else if (msg instanceof MetaMessage m) {
-                        int type = m.getType();
+						int type = m.getType();
 						byte[] data = m.getData();
 						if (type == META_TIME_SIGNATURE && foundTimeSignature == null) {
 							// TimeSignature in this class is used to keep track of source MIDIs meter.
-							// The one in TrackInfo is used to initially populate the meter field and abcsong.
+							// The one in TrackInfo is used to initially populate the meter field and
+							// abcsong.
 							// The one in AbcSong is used for output to abc.
 							try {
 								foundTimeSignature = new TimeSignature(m);
@@ -482,24 +545,25 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 									}
 								}
 							}
-						} else if (!ignoreMidiText && type == META_LYRIC && m.getData() != null) {				
+						} else if (!ignoreMidiText && type == META_LYRIC && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_LYRIC, iTrack);
-						} else if (!ignoreMidiText && type == META_TEXT && m.getData() != null) {				
+						} else if (!ignoreMidiText && type == META_TEXT && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_TEXT, iTrack);
-						} else if (!ignoreMidiText && type == META_MARKER && m.getData() != null) {			
+						} else if (!ignoreMidiText && type == META_MARKER && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_MARKER, iTrack);
-						} else if (!ignoreMidiText && type == META_CUE_POINT && m.getData() != null) {			
+						} else if (!ignoreMidiText && type == META_CUE_POINT && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_CUE_POINT, iTrack);
-						} else if (!ignoreMidiText && type == META_M_LIVE && m.getData() != null) {			
+						} else if (!ignoreMidiText && type == META_M_LIVE && m.getData() != null) {
 							midiText.collectTxt(tick, data, META_M_LIVE, iTrack);
 						} else if (m.getType() == META_COPYRIGHT && tick == 0L && iTrack == 0) {
-							log.finer("\n(c): "+MidiUtils.formatBytes(data));
+							log.finer("\n(c): " + MidiUtils.formatBytes(data));
 							String tmp = "";
-							if (!ignoreMidiText) tmp = MidiUtils.decodeMidiText(data).trim();
-							
+							if (!ignoreMidiText)
+								tmp = MidiUtils.decodeMidiText(data).trim();
+
 							if (!tmp.isEmpty()) {
 								copyright = tmp;
-								log.info("MIDI copyright: "+tmp);
+								log.info("MIDI copyright: " + tmp);
 							}
 						}
 					}
@@ -522,8 +586,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 					for (int i = 0; i < CHANNEL_COUNT_ABC; i++) {
 						boolean initAsDrums;
 
-						if (usingNewMidiLayout == 0) initAsDrums = getYamahaDrum(port, i);
-						else initAsDrums = getYamahaDrumAccurate(port, i, 0L);
+						if (usingNewMidiLayout == 0)
+							initAsDrums = getYamahaDrum(port, i);
+						else
+							initAsDrums = getYamahaDrumAccurate(port, i, 0L);
 
 						if (initAsDrums) {
 							mapMSB.put(port, i, -1L, 127);
@@ -583,30 +649,35 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 			}
 		}
 
-        // We now populate the tempo events with micros,
-        // and we calculate total durations of each tempo in use.
-        TempoEvent prevTempoEvent = null;
-        for (TempoEvent tempoEvent : tempo.values()) {
-            long tick = tempoEvent.tick;
-            if (prevTempoEvent != null) {
-                long elapsedMicros = MidiUtils.ticks2microsec(tick - prevTempoEvent.tick, prevTempoEvent.tempoMPQ, tickResolution);
-                tempoLengths.put(prevTempoEvent.tempoMPQ, elapsedMicros + Util.valueOf(tempoLengths.get(prevTempoEvent.tempoMPQ), 0));
-                tempoEvent.micros = prevTempoEvent.micros + elapsedMicros;
-            }
-            tempoByMicros.put(tempoEvent.micros, tempoEvent);//for fast micros lookup
-            prevTempoEvent = tempoEvent;
-        }
+		// We now populate the tempo events with micros,
+		// and we calculate total durations of each tempo in use.
+		TempoEvent prevTempoEvent = null;
+		for (TempoEvent tempoEvent : tempo.values()) {
+			long tick = tempoEvent.tick;
+			if (prevTempoEvent != null) {
+				long elapsedMicros = MidiUtils.ticks2microsec(tick - prevTempoEvent.tick, prevTempoEvent.tempoMPQ,
+						tickResolution);
+				tempoLengths.put(prevTempoEvent.tempoMPQ,
+						elapsedMicros + Util.valueOf(tempoLengths.get(prevTempoEvent.tempoMPQ), 0));
+				tempoEvent.micros = prevTempoEvent.micros + elapsedMicros;
+			}
+			tempoByMicros.put(tempoEvent.micros, tempoEvent);// for fast micros lookup
+			prevTempoEvent = tempoEvent;
+		}
 
 		// Account for the duration of the final tempo
-		long elapsedMicros = MidiUtils.ticks2microsec(lastTick - prevTempoEvent.tick, prevTempoEvent.tempoMPQ, tickResolution);
-		tempoLengths.put(prevTempoEvent.tempoMPQ, elapsedMicros + Util.valueOf(tempoLengths.get(prevTempoEvent.tempoMPQ), 0));
+		long elapsedMicros = MidiUtils.ticks2microsec(lastTick - prevTempoEvent.tick, prevTempoEvent.tempoMPQ,
+				tickResolution);
+		tempoLengths.put(prevTempoEvent.tempoMPQ,
+				elapsedMicros + Util.valueOf(tempoLengths.get(prevTempoEvent.tempoMPQ), 0));
 
 		// Convert the bend ranges into seminote integers.
 		// We do this after the main iteration so that the
 		// getPitchBendRange has been fully built.
 		bendMap = new MapByChannelPort(0);
 		for (Quint<Integer, Integer, Long, Long, Double> raw : pitchWheelMap) {
-			int semiToneBend = (int) Math.round(raw.fifth * getPitchBendRange(raw.first, raw.second, raw.third, raw.fourth));
+			int semiToneBend = (int) Math
+					.round(raw.fifth * getPitchBendRange(raw.first, raw.second, raw.third, raw.fourth));
 			bendMap.put(raw.first, raw.second, raw.third, semiToneBend);
 		}
 
@@ -620,15 +691,17 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		this.timeSignature = (foundTimeSignature == null) ? TimeSignature.FOUR_FOUR : foundTimeSignature;
 
 		songLengthTicks = lastTick;
-		
-		if (!ignoreMidiText && standard != MidiStandard.ABC) log.info("Lyrics stats: "+midiText.getTextStats());
+
+		if (!ignoreMidiText && standard != MidiStandard.ABC)
+			log.info("Lyrics stats: " + midiText.getTextStats());
 	}
 
 	private int getRPN(int port, int channel, long tick, long index) {
 		int msb = rpnMSBMap.get(port, channel, tick, index);
 		int lsb = rpnLSBMap.get(port, channel, tick, index);
 		if (msb != DEFAULT_RPN_NULL && lsb == DEFAULT_RPN_NULL) {// && rpnLSBMap.getEntries(channel,0L, tick).isEmpty()
-			log.severe(fileName+": Channel "+channel+", RPN being utilized while LSB is default (NULL)! Using effective value of 0 LSB.");
+			log.severe(fileName + ": Channel " + channel
+					+ ", RPN being utilized while LSB is default (NULL)! Using effective value of 0 LSB.");
 			lsb = 0;
 		}
 		return (msb << 7) | lsb;
@@ -689,7 +762,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		long patchTick = mapPatch.getEntryTick(port, channel, tick);
 		if (patchTick == NO_RESULT) {
 			// No voice changes yet on this channel, return default.
-			// TODO: Should we instead set LMB, LSB and patch to zero and let fromId handle it?
+			// TODO: Should we instead set LMB, LSB and patch to zero and let fromId handle
+			// it?
 			if (drumKit) {
 				return MidiInstrument.STANDARD_DRUM_KIT;
 			} else {
@@ -710,7 +784,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 				msb = 120;// msb 120, lsb 0 is default kit
 				lsb = 0;
 			}
-			// Roland GS standard fallback handles kit mapping natively without MSB promotion
+			// Roland GS standard fallback handles kit mapping natively without MSB
+			// promotion
 		}
 
 		String value = ExtensionMidiInstrument.getInstance().fromId(type, msb,
@@ -742,16 +817,17 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	private double getPitchBendRange(int port, int channel, long tick, long index) {
-		return pitchBendRangeCoarse.get(port, channel, tick, index) + (pitchBendRangeFine.get(port, channel, tick, index) / 100.0d);
+		return pitchBendRangeCoarse.get(port, channel, tick, index)
+				+ (pitchBendRangeFine.get(port, channel, tick, index) / 100.0d);
 	}
 
-    /**
-     * Return the duration of the sequence in ticks.
-     * NOTE: TrackInfo might have shortened the sequence,
-     *       so this value might be significantly longer than
-     *       the actual sequence we work with.
-     *       If that's an issue, use SequenceInfo.getSequence().getTickLength()
-     */
+	/**
+	 * Return the duration of the sequence in ticks.
+	 * NOTE: TrackInfo might have shortened the sequence,
+	 * so this value might be significantly longer than
+	 * the actual sequence we work with.
+	 * If that's an issue, use SequenceInfo.getSequence().getTickLength()
+	 */
 	public long getSongLengthTicks() {
 		return songLengthTicks;
 	}
@@ -799,7 +875,8 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	/*
-	 * This is used by UI to draw bar lines. By section and tune editor to edit song.
+	 * This is used by UI to draw bar lines. By section and tune editor to edit
+	 * song.
 	 * Not used by ABC exporter.
 	 */
 	public long getBarLengthTicks() {
@@ -827,36 +904,38 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		return (int) (tick / getBarLengthTicks());
 	}
 
-    /**
-     * Used in UI to show the user the play-head position and to paste its position into
-     * section bar inputs.
-     * Also used to print the bar positions in the abc file.
-     */
+	/**
+	 * Used in UI to show the user the play-head position and to paste its position
+	 * into
+	 * section bar inputs.
+	 * Also used to print the bar positions in the abc file.
+	 */
 	@Override
 	public float tickToBarNumberFloat(long tick) {
-        return (float)(Math.max(0L, tick) / (double)getBarLengthTicks());
+		return (float) (Math.max(0L, tick) / (double) getBarLengthTicks());
 	}
 
-    /**
-     * Used to convert the users section bar inputs to a tick.
-     * Cannot be changed in any way, due to backwards compatibility.
-     *
-     * Notice that 4.5 might not be in the middle of a bar time-wise etc.
-     * The reason is that tempo-changes inside the bar can change tick per time-unit.
-     */
-    public long barFloatToTick(float bar) {
-        return (long)(bar * getBarLengthTicks());
-    }
+	/**
+	 * Used to convert the users section bar inputs to a tick.
+	 * Cannot be changed in any way, due to backwards compatibility.
+	 *
+	 * Notice that 4.5 might not be in the middle of a bar time-wise etc.
+	 * The reason is that tempo-changes inside the bar can change tick per
+	 * time-unit.
+	 */
+	public long barFloatToTick(float bar) {
+		return (long) (bar * getBarLengthTicks());
+	}
 
 	public NavigableMap<Long, TempoEvent> getTempoEvents() {
 		return tempo;
 	}
 
-    public boolean isTempoInHigherTracks() {
-        return tempoInHigherTracks;
-    }
+	public boolean isTempoInHigherTracks() {
+		return tempoInHigherTracks;
+	}
 
-    /**
+	/**
 	 * Tempo Handling
 	 */
 	public static class TempoEvent {
@@ -871,10 +950,11 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		public final int tempoMPQ;
 		public final long tick;
 		public long micros;
-		
+
 		@Override
 		public String toString() {
-			return "BPM="+MidiUtils.convertTempo(tempoMPQ)+" MPQ="+tempoMPQ+"  tick="+tick+"  micros="+micros;
+			return "BPM=" + MidiUtils.convertTempo(tempoMPQ) + " MPQ=" + tempoMPQ + "  tick=" + tick + "  micros="
+					+ micros;
 		}
 	}
 
@@ -882,9 +962,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		return new TempoEvent(tempoMPQ, startTick, startMicros);
 	}
 
-    /**
-     * Floor
-     */
+	/**
+	 * Floor
+	 */
 	public TempoEvent getTempoEventForTick(long tick) {
 		Entry<Long, TempoEvent> entry = tempo.floorEntry(tick);
 		if (entry != null)
@@ -894,9 +974,9 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	public TempoEvent getTempoEventForMicros(long micros) {
-        Entry<Long, TempoEvent> entry = tempoByMicros.floorEntry(micros);
-        if (entry != null)
-            return entry.getValue();
+		Entry<Long, TempoEvent> entry = tempoByMicros.floorEntry(micros);
+		if (entry != null)
+			return entry.getValue();
 
 		return TempoEvent.DEFAULT_TEMPO;
 	}
@@ -916,11 +996,11 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	public void setCopyright(String copyright) {
 		this.copyright = copyright;
 	}
-	
+
 	/**
 	 * Never call this when app is Abc Tools
 	 */
-	 public String getLyrics() {
+	public String getLyrics() {
 		return midiText.getText();
 	}
 
@@ -930,11 +1010,11 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	public List<LyricLine> getLyricLines() {
 		return midiText.getStructuredLyrics();
 	}
-	
+
 	public String getGenre() {
 		return midiText.genre;
 	}
-	
+
 	public String getComposer() {
 		return midiText.artist;
 	}
@@ -944,7 +1024,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	private boolean getYamahaDrum(int port, int channel) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (yamahaDrumChannels.get(port) == null) {
 			yamahaDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			yamahaDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -953,7 +1033,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	private boolean getRolandDrum(int port, int channel) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (rolandDrumChannels.get(port) == null) {
 			rolandDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			rolandDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -962,20 +1042,28 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 	}
 
 	private boolean getYamahaDrumAccurate(int port, int channel, long tick) {
-		port = usingNewMidiLayout==0?0:port;
-		if (yamahaDrumSwitches == null) return getYamahaDrum(port, channel);
-		if (yamahaDrumSwitches.get(port) == null) return getYamahaDrum(port, channel);
-		if (yamahaDrumSwitches.get(port).get(channel) == null) return getYamahaDrum(port, channel);
-		if (yamahaDrumSwitches.get(port).get(channel).floorEntry(tick) == null) return getYamahaDrum(port, channel);
+		port = usingNewMidiLayout == 0 ? 0 : port;
+		if (yamahaDrumSwitches == null)
+			return getYamahaDrum(port, channel);
+		if (yamahaDrumSwitches.get(port) == null)
+			return getYamahaDrum(port, channel);
+		if (yamahaDrumSwitches.get(port).get(channel) == null)
+			return getYamahaDrum(port, channel);
+		if (yamahaDrumSwitches.get(port).get(channel).floorEntry(tick) == null)
+			return getYamahaDrum(port, channel);
 		return yamahaDrumSwitches.get(port).get(channel).floorEntry(tick).getValue();
 	}
 
 	private boolean getMmaDrumAccurate(int port, int channel, long tick) {
-		port = usingNewMidiLayout==0?0:port;
-		if (mmaDrumSwitches == null) return channel == DRUM_CHANNEL;
-		if (mmaDrumSwitches.get(port) == null) return channel == DRUM_CHANNEL;
-		if (mmaDrumSwitches.get(port).get(channel) == null) return channel == DRUM_CHANNEL;
-		if (mmaDrumSwitches.get(port).get(channel).floorEntry(tick) == null) return channel == DRUM_CHANNEL;
+		port = usingNewMidiLayout == 0 ? 0 : port;
+		if (mmaDrumSwitches == null)
+			return channel == DRUM_CHANNEL;
+		if (mmaDrumSwitches.get(port) == null)
+			return channel == DRUM_CHANNEL;
+		if (mmaDrumSwitches.get(port).get(channel) == null)
+			return channel == DRUM_CHANNEL;
+		if (mmaDrumSwitches.get(port).get(channel).floorEntry(tick) == null)
+			return channel == DRUM_CHANNEL;
 		return mmaDrumSwitches.get(port).get(channel).floorEntry(tick).getValue();
 	}
 
@@ -1163,8 +1251,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 				return new HashSet<>();
 			SortedMap<MsgKey, Integer> subMap = map[port][channel].subMap(
 					new MsgKey(fromTick, 0L),
-					new MsgKey(toTick, 0L)
-			);
+					new MsgKey(toTick, 0L));
 			return subMap.entrySet();
 		}
 
@@ -1179,7 +1266,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 			return entry.getKey().tick;
 		}
 	}
-	
+
 	public enum DrumBankType {
 		NOT_DRUM,
 		XG_DRUM,

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -344,7 +344,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 											String message = fileName + "; Channel " + ch + " Port " + port
 													+ ": Clamping fine pitch bend wheel range out of bounds: "
 													+ shortMsg.getData2() + " cents.";
-											logMessage(Level.WARNING, message);
+									logMessage(Level.INFO, message);
 										}
 										pitchBendRangeFine.put(port, ch, tick, jj,
 												Math.clamp(shortMsg.getData2(), 0, 99));

--- a/src/com/digero/maestro/midi/SequenceDataCache.java
+++ b/src/com/digero/maestro/midi/SequenceDataCache.java
@@ -724,7 +724,10 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 		}
 	}
 
-	private void logMessage(Level warning, String message) {
+	private void logMessage(Level level, String message) {
+		if (message == null || !log.isLoggable(level)) {
+			return;
+		}
 		message = message
 				.replace('\r', ' ')
 				.replace('\n', ' ')
@@ -732,7 +735,7 @@ public class SequenceDataCache implements MidiConstants, ITempoCache, IBarNumber
 				.replaceAll("\\p{Cntrl}", "")
 				.replaceAll(" +", " ")
 				.trim();
-		log.log(warning, message);
+		log.log(level, message);
 	}
 
 	private int getRPN(int port, int channel, long tick, long index) {

--- a/src/com/digero/maestro/midi/SequenceInfo.java
+++ b/src/com/digero/maestro/midi/SequenceInfo.java
@@ -2,6 +2,7 @@ package com.digero.maestro.midi;
 
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.sound.midi.InvalidMidiDataException;
@@ -164,7 +165,8 @@ public class SequenceInfo implements MidiConstants {
 		this.lastTrackInfos = abcInfo == null ? null : abcInfo.abcTrackInfos;
 		this.onlyFirstTrackTempos = onlyFirstTrackTempos;// if user toggles this, we create a whole new sequenceInfo
 															// instance.
-		log.fine("Importing (Type " + type + "): " + fileName);
+		String message = "Importing (Type " + type + "): " + fileName;
+		logMessage(Level.FINE, message);
 
 		/*
 		 * // debug seq part 1:
@@ -264,9 +266,31 @@ public class SequenceInfo implements MidiConstants {
 		this.trackInfoList = Collections.unmodifiableList(myTrackInfoList);
 		if (!getTimeSignature().equals(sequenceCache.getTimeSignature())) {
 			// If see this output then..
-			log.severe("Time signature does not match between SequenceInfo (" + getTimeSignature()
-					+ ") and SequenceDataCache (" + sequenceCache.getTimeSignature() + ").");
+			message = "Time signature does not match between SequenceInfo (" + getTimeSignature()
+					+ ") and SequenceDataCache (" + sequenceCache.getTimeSignature() + ").";
+			logMessage(Level.SEVERE, message);
 		}
+	}
+
+	/**
+	 * Log a message, but first clean it up so it doesn't have newlines or tabs in
+	 * it.
+	 * 
+	 * @param level   The logging level
+	 * @param message The message to log
+	 */
+	private static void logMessage(Level level, String message) {
+		if (message == null || !log.isLoggable(level)) {
+			return;
+		}
+		message = message
+				.replace('\r', ' ')
+				.replace('\n', ' ')
+				.replace('\t', ' ')
+				.replaceAll("\\p{Cntrl}", "")
+				.replaceAll(" +", " ")
+				.trim();
+		log.log(level, message);
 	}
 
 	/**
@@ -319,16 +343,20 @@ public class SequenceInfo implements MidiConstants {
 						byte[] portChange = meta.getData();
 						if (portChange.length == 1) {
 							port = (int) portChange[0] & 0xFF;
-							log.fine("Port change on track " + iiTrack + ", tick " + tick + ", port " + port);
+							String message = "Port change on track " + iiTrack + ", tick " + tick + ", port " + port;
+							logMessage(Level.FINE, message);
 							havePorts = true;
 							portMap.put(iiTrack, port);
 							break;
 						}
 					} else if (meta.getType() == META_PORT_NAME) {
 						byte[] data = meta.getData();
-						log.warning(fileName + ": Named port " + new String(data));// abc tools also use this line, no
-																					// icu in jar, so dont call charset
-																					// analyser.
+						String message = fileName + ": Named port " + new String(data);// abc tools also use this line,
+																						// no
+																						// icu in jar, so dont call
+																						// charset
+																						// analyser.
+						logMessage(Level.WARNING, message);
 					}
 				}
 			}
@@ -732,17 +760,18 @@ public class SequenceInfo implements MidiConstants {
 					// the "& 0xFF" is to convert to unsigned int from signed byte.
 					if (MidiUtils.isResetXG(message)) {
 						if (MidiStandard.GM != standard && MidiStandard.XG != standard) {
-							log.info(fileName + ": MIDI XG Reset in a " + standard + " file. This is unusual!");
+							String logMsg = fileName + ": MIDI XG Reset in a " + standard + " file. This is unusual!";
+							logMessage(Level.INFO, logMsg);
 						}
 						if (evt.getTick() > lastResetTick) {
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.XG;
 						} else if (MidiStandard.GS == standard && evt.getTick() == lastResetTick) {
-							log.info(
-									"They are at same tick. Statistically bigger chance its a GS, so not switching to XG.");
+							String logMsg = "They are at same tick. Statistically bigger chance its a GS, so not switching to XG.";
+							logMessage(Level.INFO, logMsg);
 						} else if (MidiStandard.GM2 == standard && evt.getTick() == lastResetTick) {
-							log.info(
-									"They are at same tick. Statistically bigger chance its a XG, so switching to that.");
+							String logMsg = "They are at same tick. Statistically bigger chance its a XG, so switching to that.";
+							logMessage(Level.INFO, logMsg);
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.XG;
 						}
@@ -750,7 +779,8 @@ public class SequenceInfo implements MidiConstants {
 						// System.err.println("Yamaha XG Reset, tick "+evt.getTick());
 					} else if (MidiUtils.isResetGS(message, usingNewMidiLayout > 0)) {
 						if (MidiStandard.GM != standard && MidiStandard.GS != standard) {
-							log.info(fileName + ": MIDI GS Reset in a " + standard + " file. This is unusual!");
+							String logMsg = fileName + ": MIDI GS Reset in a " + standard + " file. This is unusual!";
+							logMessage(Level.INFO, logMsg);
 						}
 						if (evt.getTick() >= lastResetTick) {
 							lastResetTick = evt.getTick();
@@ -760,14 +790,15 @@ public class SequenceInfo implements MidiConstants {
 						// System.err.println("Roland GS Reset, tick "+evt.getTick());
 					} else if (MidiUtils.isResetGM2(message)) {
 						if (MidiStandard.GM != standard && MidiStandard.GM2 != standard) {
-							log.info(fileName + ": MIDI GM2 Reset in a " + standard + " file. This is unusual!");
+							String logMsg = fileName + ": MIDI GM2 Reset in a " + standard + " file. This is unusual!";
+							logMessage(Level.INFO, logMsg);
 						}
 						if (evt.getTick() > lastResetTick) {
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.GM2;
 						} else if (evt.getTick() == lastResetTick && MidiStandard.GM != standard) {
-							log.info(
-									"They are at same tick. Statistically bigger chance its not a GM2, so not switching standard.");
+							String logMsg = "They are at same tick. Statistically bigger chance its not a GM2, so not switching standard.";
+							logMessage(Level.INFO, logMsg);
 						}
 						ExtensionMidiInstrument.getInstance();
 						// System.err.println("MIDI GM2 Reset, tick "+evt.getTick());
@@ -859,8 +890,9 @@ public class SequenceInfo implements MidiConstants {
 						// Ignoring this sysex as I have tested 130,000 midi files and none of them had
 						// an OFF,
 						// so its super rare.
-						log.warning(
-								fileName + ": Yamaha XG Drum Part Protect mode " + (message[7] == 0 ? "OFF" : "ON"));
+						String logMsg = fileName + ": Yamaha XG Drum Part Protect mode "
+								+ (message[7] == 0 ? "OFF" : "ON");
+						logMessage(Level.WARNING, logMsg);
 					} else if (message.length == 9 && (message[0] & 0xFF) == 0xF0 && (message[1] & 0xFF) == 0x43
 							&& (message[3] & 0xFF) == 0x4C // this check can change the listed instr, but that does not
 															// break back compat
@@ -1326,9 +1358,11 @@ public class SequenceInfo implements MidiConstants {
 					byte[] data = meta.getData();
 					if (data.length > 0)
 						port = data[0] & 0xFF;
-					if (port > 127)
-						log.warning(fileName + ": Port number out of range: " + port
-								+ ". File might not be interpreted correctly.");
+					if (port > 127) {
+						String logMsg = fileName + ": Port number out of range: " + port
+								+ ". File might not be interpreted correctly.";
+						logMessage(Level.WARNING, logMsg);
+					}
 					break;
 				}
 			}
@@ -1591,7 +1625,8 @@ public class SequenceInfo implements MidiConstants {
 	 *
 	 */
 	public long fixupTrackLength2(Sequence song) {
-		log.fine("Before: " + Util.formatDurationM(song.getMicrosecondLength()));
+		String logMsg = "Before: " + Util.formatDurationM(song.getMicrosecondLength());
+		logMessage(Level.FINE, logMsg);
 		SequencerWrapper.TempoCacheSlow tempoCache = new SequencerWrapper.TempoCacheSlow(song);
 
 		long maxEmpty = Math.max(song.getTickLength() / 4L,
@@ -1657,7 +1692,8 @@ public class SequenceInfo implements MidiConstants {
 						break;
 				}
 				if (silence) {
-					log.warning(fileName + ": Quarter song is empty, will delete all after the empty starts.");
+					logMsg = fileName + ": Quarter song is empty, will delete all after the empty starts.";
+					logMessage(Level.WARNING, logMsg);
 				} else {
 					earlyEndTick = tick;
 				}
@@ -1692,7 +1728,8 @@ public class SequenceInfo implements MidiConstants {
 				}
 			}
 		}
-		log.fine("endTick = " + endTick + " earlyEndTick=" + earlyEndTick);
+		logMsg = fileName + ": endTick = " + endTick + " earlyEndTick=" + earlyEndTick;
+		logMessage(Level.FINE, logMsg);
 		long absoluteEnd = Math.min(earlyEndTick, endTick);
 
 		for (int i = 0; i < tracks.length; i++) {
@@ -1715,9 +1752,10 @@ public class SequenceInfo implements MidiConstants {
 						// Non-tempo MetaMessages (like track names, text, lyrics) get salvaged
 						metaToRelocate.add(evt);
 						toRemove.add(evt);
-						log.finer("Moving event from "
+						logMsg = "Moving event from "
 								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, tick, tempoCache)) + " to "
-								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, trackCutoff, tempoCache)));
+								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, trackCutoff, tempoCache));
+						logMessage(Level.FINER, logMsg);
 					} else {
 						// ShortMessages (notes, CCs, bends), Sysex, and Tempos get marked for deletion
 						toRemove.add(evt);
@@ -1739,7 +1777,8 @@ public class SequenceInfo implements MidiConstants {
 
 		// System.out.println("Real song duration: "
 		// + Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
-		log.fine("After: " + Util.formatDurationM(song.getMicrosecondLength()));
+		logMsg = fileName + ": After: " + Util.formatDurationM(song.getMicrosecondLength());
+		logMessage(Level.FINE, logMsg);
 		return absoluteEnd + 1L;
 	}
 
@@ -1747,7 +1786,8 @@ public class SequenceInfo implements MidiConstants {
 	 * The old method, we keep it for backwards compat.
 	 */
 	public static long fixupTrackLength1(Sequence song) {
-		log.fine("Before: " + Util.formatDurationM(song.getMicrosecondLength()));
+		String logMsg = "Before: " + Util.formatDurationM(song.getMicrosecondLength());
+		logMessage(Level.FINE, logMsg);
 		SequencerWrapper.TempoCacheSlow tempoCache = new SequencerWrapper.TempoCacheSlow(song);
 		Track[] tracks = song.getTracks();
 
@@ -1785,7 +1825,8 @@ public class SequenceInfo implements MidiConstants {
 					}
 				}
 				if (silence) {
-					log.info(" Quarter song is empty, will delete all after the empty starts.. ");
+					logMsg = "Quarter song is empty, will delete all after the empty starts.";
+					logMessage(Level.WARNING, logMsg);
 				} else {
 					earlyEndTick = evt.getTick();
 				}
@@ -1828,14 +1869,16 @@ public class SequenceInfo implements MidiConstants {
 									&& ((ShortMessage) evt.getMessage()).getData2() == 0)) {
 								// note OFF or note ON with zero velocity
 								endTick = evt.getTick();
-								log.finer(i + ": last note OFF = " + MidiUtils.midiEventToShortString(evt));
+								logMsg = i + ": last note OFF = " + MidiUtils.midiEventToShortString(evt);
+								logMessage(Level.FINER, logMsg);
 								break;
 							}
 							if (command == ShortMessage.NOTE_ON && lastEOT != null) {
 								// last note is missing note off, so it should end at EOT
 								// if no EOT after it, we ignore it.
 								endTick = lastEOT.getTick();
-								log.finer(i + ": endTick = lastEOT = " + endTick);
+								logMsg = i + ": endTick = lastEOT = " + endTick;
+								logMessage(Level.FINER, logMsg);
 								break;
 							}
 						}
@@ -1843,7 +1886,8 @@ public class SequenceInfo implements MidiConstants {
 				}
 			}
 		}
-		log.fine("endTick = " + endTick + " earlyEndTick=" + earlyEndTick);
+		logMsg = "endTick = " + endTick + " earlyEndTick=" + earlyEndTick;
+		logMessage(Level.FINE, logMsg);
 
 		/*
 		 * Weakness in this, is that if there is note OFF far at end without
@@ -1860,10 +1904,11 @@ public class SequenceInfo implements MidiConstants {
 					if (evt.getTick() > endTick) {
 						track.remove(evt);
 
-						log.finer("Moving event from "
+						logMsg = "Moving event from "
 								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, evt.getTick(), tempoCache))
 								+ " to "
-								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, endTick, tempoCache)));
+								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, endTick, tempoCache));
+						logMessage(Level.FINER, logMsg);
 
 						// Why do we do this, events after endTick don't affect song,
 						// so why keep them? (unless its a EOT)
@@ -1894,7 +1939,8 @@ public class SequenceInfo implements MidiConstants {
 					trackEndTick = Math.min(Math.min(earlyEndTick, endTick), track.get(track.size() - 1).getTick());
 				MidiEvent end = MidiFactory.createEndOfTrackEvent(trackEndTick + 1);
 				track.add(end);
-				log.finest("Track " + i + " was missing an EndOfTrack. It was now inserted.");
+				logMsg = "Track " + i + " was missing an EndOfTrack. It was now inserted.";
+				logMessage(Level.FINEST, logMsg);
 			}
 		}
 
@@ -1914,7 +1960,8 @@ public class SequenceInfo implements MidiConstants {
 
 		// System.out.println("Real song duration: "
 		// + Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
-		log.fine("After: " + Util.formatDurationM(song.getMicrosecondLength()));
+		logMsg = "After: " + Util.formatDurationM(song.getMicrosecondLength());
+		logMessage(Level.FINE, logMsg);
 		return earlyEndTick + 1L;
 	}
 

--- a/src/com/digero/maestro/midi/SequenceInfo.java
+++ b/src/com/digero/maestro/midi/SequenceInfo.java
@@ -2,6 +2,7 @@ package com.digero.maestro.midi;
 
 import java.io.*;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -165,8 +166,8 @@ public class SequenceInfo implements MidiConstants {
 		this.lastTrackInfos = abcInfo == null ? null : abcInfo.abcTrackInfos;
 		this.onlyFirstTrackTempos = onlyFirstTrackTempos;// if user toggles this, we create a whole new sequenceInfo
 															// instance.
-		String message = "Importing (Type " + type + "): " + fileName;
-		logMessage(Level.FINE, message);
+		String logMsg = "Importing (Type " + type + "): " + fileName;
+		logMessage(Level.FINE, logMsg);
 
 		/*
 		 * // debug seq part 1:
@@ -266,15 +267,15 @@ public class SequenceInfo implements MidiConstants {
 		this.trackInfoList = Collections.unmodifiableList(myTrackInfoList);
 		if (!getTimeSignature().equals(sequenceCache.getTimeSignature())) {
 			// If see this output then..
-			message = "Time signature does not match between SequenceInfo (" + getTimeSignature()
+			logMsg = "Time signature does not match between SequenceInfo (" + getTimeSignature()
 					+ ") and SequenceDataCache (" + sequenceCache.getTimeSignature() + ").";
-			logMessage(Level.SEVERE, message);
+			logMessage(Level.SEVERE, logMsg);
 		}
 	}
 
 	/**
-	 * Log a message, but first clean it up so it doesn't have newlines or tabs in
-	 * it.
+	 * Log a message, but first clean it up so it doesn't have newlines or tabs,
+	 * control characters and multiple spaces in a row.
 	 * 
 	 * @param level   The logging level
 	 * @param message The message to log
@@ -291,6 +292,20 @@ public class SequenceInfo implements MidiConstants {
 				.replaceAll(" +", " ")
 				.trim();
 		log.log(level, message);
+	}
+
+	/**
+	 * Log a message, but first clean it up so it doesn't have newlines or tabs,
+	 * control characters and multiple spaces in a row.
+	 * 
+	 * @param finer          The logging level
+	 * @param logMsgSupplier The supplier for the message to log
+	 */
+	private void logMessage(Level finer, Supplier<String> logMsgSupplier) {
+		if (logMsgSupplier == null || !log.isLoggable(finer)) {
+			return;
+		}
+		logMessage(finer, logMsgSupplier.get());
 	}
 
 	/**
@@ -343,20 +358,20 @@ public class SequenceInfo implements MidiConstants {
 						byte[] portChange = meta.getData();
 						if (portChange.length == 1) {
 							port = (int) portChange[0] & 0xFF;
-							String message = "Port change on track " + iiTrack + ", tick " + tick + ", port " + port;
-							logMessage(Level.FINE, message);
+							String logMsg = "Port change on track " + iiTrack + ", tick " + tick + ", port " + port;
+							logMessage(Level.FINE, logMsg);
 							havePorts = true;
 							portMap.put(iiTrack, port);
 							break;
 						}
 					} else if (meta.getType() == META_PORT_NAME) {
 						byte[] data = meta.getData();
-						String message = fileName + ": Named port " + new String(data);// abc tools also use this line,
+						String logMsg = fileName + ": Named port " + new String(data);// abc tools also use this line,
 																						// no
 																						// icu in jar, so dont call
 																						// charset
 																						// analyser.
-						logMessage(Level.WARNING, message);
+						logMessage(Level.WARNING, logMsg);
 					}
 				}
 			}
@@ -1752,10 +1767,10 @@ public class SequenceInfo implements MidiConstants {
 						// Non-tempo MetaMessages (like track names, text, lyrics) get salvaged
 						metaToRelocate.add(evt);
 						toRemove.add(evt);
-						logMsg = "Moving event from "
+						Supplier<String> logMsgSupplier = () -> "Moving event from "
 								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, tick, tempoCache)) + " to "
 								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, trackCutoff, tempoCache));
-						logMessage(Level.FINER, logMsg);
+						logMessage(Level.FINER, logMsgSupplier);
 					} else {
 						// ShortMessages (notes, CCs, bends), Sysex, and Tempos get marked for deletion
 						toRemove.add(evt);
@@ -1826,7 +1841,7 @@ public class SequenceInfo implements MidiConstants {
 				}
 				if (silence) {
 					logMsg = "Quarter song is empty, will delete all after the empty starts.";
-					logMessage(Level.WARNING, logMsg);
+					logMessage(Level.INFO, logMsg);
 				} else {
 					earlyEndTick = evt.getTick();
 				}

--- a/src/com/digero/maestro/midi/SequenceInfo.java
+++ b/src/com/digero/maestro/midi/SequenceInfo.java
@@ -34,7 +34,8 @@ import com.digero.maestro.abc.AbcExporter.ExportTrackInfo;
 import com.digero.maestro.view.MiscSettings;
 
 /**
- * Container for a MIDI sequence. If necessary, converts type 0 MIDI files to type 1.
+ * Container for a MIDI sequence. If necessary, converts type 0 MIDI files to
+ * type 1.
  */
 public class SequenceInfo implements MidiConstants {
 	private static final Logger log = Logger.getLogger("import.midi");
@@ -49,11 +50,13 @@ public class SequenceInfo implements MidiConstants {
 	public boolean hasPorts = false;
 	public int midiType = -1;// -1 = abc, 0 = type 0, 1 = type 1, 2 = type 2
 	private int usingNewMidiLayout;// 0 = back compat, 1 = fixed some stuff.
-	private final Map<Integer, ArrayList<Boolean>> rolandDrumChannels = new HashMap<>();// Which of the channels GS designates as
-																			// drums
-	private final Map<Integer, ArrayList<Boolean>> yamahaDrumChannels = new HashMap<>();// Which of the channels XG designates as
-																			// drums
-																			// Change these two fields to Sparse Maps:
+	private final Map<Integer, ArrayList<Boolean>> rolandDrumChannels = new HashMap<>();// Which of the channels GS
+																						// designates as
+	// drums
+	private final Map<Integer, ArrayList<Boolean>> yamahaDrumChannels = new HashMap<>();// Which of the channels XG
+																						// designates as
+	// drums
+	// Change these two fields to Sparse Maps:
 	// Which channel/tick XG switches to drums
 	// outside of designated drum channels
 	private final Map<Integer, ArrayList<TreeMap<Long, Boolean>>> yamahaDrumSwitches = new HashMap<>();
@@ -71,19 +74,21 @@ public class SequenceInfo implements MidiConstants {
 	private List<ExportTrackInfo> lastTrackInfos = null;
 
 	public long realDuraTicks;
-    public final PolyphonyHistogram histogram;
-    public final DissonanceDetector dissonance;
+	public final PolyphonyHistogram histogram;
+	public final DissonanceDetector dissonance;
 
-    private static final Object PREVIEW_EXPORT_LOCK = new Object();
+	private static final Object PREVIEW_EXPORT_LOCK = new Object();
 
 	/**
 	 * Create instance of this class while creating MIDI sequence from abc file.
 	 */
-	public static SequenceInfo fromAbc(AbcToMidi.Params params, MiscSettings miscSettings, boolean oldVelocities, boolean ignoreMidiText, int usingNewMidiLayout)
+	public static SequenceInfo fromAbc(AbcToMidi.Params params, MiscSettings miscSettings, boolean oldVelocities,
+			boolean ignoreMidiText, int usingNewMidiLayout)
 			throws InvalidMidiDataException, FileParseException {
 		if (params.abcInfo == null)
 			params.abcInfo = new AbcInfo();
-		SequenceInfo sequenceInfo = new SequenceInfo(params.filesData.getFirst().file.getName(), AbcToMidi.convert(params),
+		SequenceInfo sequenceInfo = new SequenceInfo(params.filesData.getFirst().file.getName(),
+				AbcToMidi.convert(params),
 				-1, miscSettings, oldVelocities, true, false, ignoreMidiText, params.abcInfo, usingNewMidiLayout, null);
 		sequenceInfo.title = params.abcInfo.getTitle();
 		sequenceInfo.composer = params.abcInfo.getComposer();
@@ -94,96 +99,107 @@ public class SequenceInfo implements MidiConstants {
 	/**
 	 * Create instance of this class while creating sequence from MIDI file
 	 */
-	public static SequenceInfo fromMidi(File midiFile, MiscSettings miscSettings, boolean oldVelocities, boolean onlyFirstTrackTempos, boolean ignoreZeroChannelVolume, boolean ignoreMidiText, int usingNewMidiLayout)
+	public static SequenceInfo fromMidi(File midiFile, MiscSettings miscSettings, boolean oldVelocities,
+			boolean onlyFirstTrackTempos, boolean ignoreZeroChannelVolume, boolean ignoreMidiText,
+			int usingNewMidiLayout)
 			throws InvalidMidiDataException, IOException, FileParseException {
-        try (InputStream is1 = new BufferedInputStream(new FileInputStream(midiFile));
-             InputStream is2 = new BufferedInputStream(new FileInputStream(midiFile))) {
+		try (InputStream is1 = new BufferedInputStream(new FileInputStream(midiFile));
+				InputStream is2 = new BufferedInputStream(new FileInputStream(midiFile))) {
 
-            Sequence sequence = MidiSystem.getSequence(is1);
-            MidiFileFormat midiFileFormat = MidiSystem.getMidiFileFormat(is2);
-            return new SequenceInfo(midiFile.getName(), ConvertPPQ.convert(sequence),
-                    midiFileFormat.getType(), miscSettings, oldVelocities, onlyFirstTrackTempos, ignoreZeroChannelVolume,
-                    ignoreMidiText, null, usingNewMidiLayout, midiFile);
-        }
+			Sequence sequence = MidiSystem.getSequence(is1);
+			MidiFileFormat midiFileFormat = MidiSystem.getMidiFileFormat(is2);
+			return new SequenceInfo(midiFile.getName(), ConvertPPQ.convert(sequence),
+					midiFileFormat.getType(), miscSettings, oldVelocities, onlyFirstTrackTempos,
+					ignoreZeroChannelVolume,
+					ignoreMidiText, null, usingNewMidiLayout, midiFile);
+		}
 	}
 
-    /**
-     * Create an instance of this class for unit-testing
-     */
-    public static SequenceInfo fromSequence(Sequence seq, MiscSettings miscSettings)
-            throws InvalidMidiDataException, FileParseException {
-        return new SequenceInfo("unit-test", seq,
-                1, miscSettings, false, true, true, true, null, 0, null);
-    }
+	/**
+	 * Create an instance of this class for unit-testing
+	 */
+	public static SequenceInfo fromSequence(Sequence seq, MiscSettings miscSettings)
+			throws InvalidMidiDataException, FileParseException {
+		return new SequenceInfo("unit-test", seq,
+				1, miscSettings, false, true, true, true, null, 0, null);
+	}
 
 	/**
 	 * Create instance of this class while creating preview MIDI file
 	 */
 	public static SequenceInfo fromAbcParts(AbcExporter abcExporter, boolean useLotroInstruments, boolean oldVelocities)
 			throws InvalidMidiDataException, AbcConversionException {
-        synchronized (PREVIEW_EXPORT_LOCK) {
-            // lock so ProjectFrame don't go in here before previous is finished
-            return new SequenceInfo(abcExporter, useLotroInstruments);
-        }
+		synchronized (PREVIEW_EXPORT_LOCK) {
+			// lock so ProjectFrame don't go in here before previous is finished
+			return new SequenceInfo(abcExporter, useLotroInstruments);
+		}
 	}
 
-    /**
-     * Will export a new preview using a deep copy of AbcSong.
-     * QTM and SequenceInfo are not copied, so the source must not change while in progress.
-     */
-    public static SequenceInfo fromAbcParts(AbcSong abcSong, boolean useLotroInstruments, boolean oldVelocities)
-            throws InvalidMidiDataException, AbcConversionException {
-        synchronized (PREVIEW_EXPORT_LOCK) {
-            AbcExporter exportCopy = abcSong.getAbcExporter();
-            // lock so ProjectFrame worker threads don't go in here before previous is finished
-            return new SequenceInfo(exportCopy, useLotroInstruments);
-        }
-    }
+	/**
+	 * Will export a new preview using a deep copy of AbcSong.
+	 * QTM and SequenceInfo are not copied, so the source must not change while in
+	 * progress.
+	 */
+	public static SequenceInfo fromAbcParts(AbcSong abcSong, boolean useLotroInstruments, boolean oldVelocities)
+			throws InvalidMidiDataException, AbcConversionException {
+		synchronized (PREVIEW_EXPORT_LOCK) {
+			AbcExporter exportCopy = abcSong.getAbcExporter();
+			// lock so ProjectFrame worker threads don't go in here before previous is
+			// finished
+			return new SequenceInfo(exportCopy, useLotroInstruments);
+		}
+	}
 
-	private SequenceInfo(String fileName, Sequence sequence, int type, MiscSettings miscSettings, boolean oldVelocities, boolean onlyFirstTrackTempos, boolean ignoreZeroChannelVolume, boolean ignoreMidiText, AbcInfo abcInfo, int usingNewMidiLayout, File midiFile)
+	private SequenceInfo(String fileName, Sequence sequence, int type, MiscSettings miscSettings, boolean oldVelocities,
+			boolean onlyFirstTrackTempos, boolean ignoreZeroChannelVolume, boolean ignoreMidiText, AbcInfo abcInfo,
+			int usingNewMidiLayout, File midiFile)
 			throws InvalidMidiDataException, FileParseException {
 		this.usingNewMidiLayout = usingNewMidiLayout;
 		this.midiFile = midiFile;
 		this.fileName = fileName;
 
 		this.midiType = type;
-        this.histogram = null;
-        this.dissonance = null;
-        this.lastTrackInfos = abcInfo==null?null:abcInfo.abcTrackInfos;
-		this.onlyFirstTrackTempos = onlyFirstTrackTempos;// if user toggles this, we create a whole new sequenceInfo instance.
-		log.fine("Importing (Type "+type+"): "+fileName);
+		this.histogram = null;
+		this.dissonance = null;
+		this.lastTrackInfos = abcInfo == null ? null : abcInfo.abcTrackInfos;
+		this.onlyFirstTrackTempos = onlyFirstTrackTempos;// if user toggles this, we create a whole new sequenceInfo
+															// instance.
+		log.fine("Importing (Type " + type + "): " + fileName);
 
 		/*
-		// debug seq part 1:
-		System.out.println("PPQ resolution="+sequence.getResolution());
-		System.out.println("  Before processing");
-		Track[] trcks = sequence.getTracks();
-		for (int track = 0; track < trcks.length; track++) {
-			//if (track != 0 && track != 24) continue;
-			Track t = trcks[track];
-			System.out.println("\nTrack "+track+":");
-			for (int j = 0; j < t.size(); j++) {
-				MidiEvent evt = t.get(j);
-				//if (evt.getTick() > 100_000L) break;
-				System.out.printf("Tick %08d: %s\n",evt.getTick(), MidiUtils.midiMessageToString(evt.getMessage()));
-			}
-		}
-		*/
+		 * // debug seq part 1:
+		 * System.out.println("PPQ resolution="+sequence.getResolution());
+		 * System.out.println("  Before processing");
+		 * Track[] trcks = sequence.getTracks();
+		 * for (int track = 0; track < trcks.length; track++) {
+		 * //if (track != 0 && track != 24) continue;
+		 * Track t = trcks[track];
+		 * System.out.println("\nTrack "+track+":");
+		 * for (int j = 0; j < t.size(); j++) {
+		 * MidiEvent evt = t.get(j);
+		 * //if (evt.getTick() > 100_000L) break;
+		 * System.out.printf("Tick %08d: %s\n",evt.getTick(),
+		 * MidiUtils.midiMessageToString(evt.getMessage()));
+		 * }
+		 * }
+		 */
 
 		determineStandard(sequence, fileName);
 
 		// Since the drum track separation is only applicable to type 1 midi sequences,
-		// do it before we convert this sequence to type 1, to avoid doing unnecessary work
-		// Aifel: changed order so that XG drums in middle of a track from a type 0 gets separated out
+		// do it before we convert this sequence to type 1, to avoid doing unnecessary
+		// work
+		// Aifel: changed order so that XG drums in middle of a track from a type 0 gets
+		// separated out
 		boolean wasType0 = convertToType1(sequence);
 
-        this.sequence = separateDrumTracks(sequence);// Beware: Do not refer to param 'sequence' after this line
+		this.sequence = separateDrumTracks(sequence);// Beware: Do not refer to param 'sequence' after this line
 
-		hasPorts = buildPortMap();//fixupTrackLength2 needs portMap
+		hasPorts = buildPortMap();// fixupTrackLength2 needs portMap
 
 		if (usingNewMidiLayout >= 1) {
-        	normalizeOverlappingVoices(this.sequence);
- 		}
+			normalizeOverlappingVoices(this.sequence);
+		}
 
 		if (usingNewMidiLayout == 0) {
 			realDuraTicks = fixupTrackLength1(this.sequence);
@@ -210,26 +226,27 @@ public class SequenceInfo implements MidiConstants {
 					sequenceCache.isGM2DrumsTrack(i), miscSettings, oldVelocities, ignoreMidiText, usingNewMidiLayout));
 		}
 
-/*
-		// debug seq part 2:
-		System.out.println("  After processing");
-		Track[] trcks2 = this.sequence.getTracks();
-		for (int track = 0; track < trcks2.length; track++) {
-			//if (track != 0 && track != 1 && track != 2 && track != 13) continue;
-			Track t = trcks2[track];
-			System.out.println("\nTrack "+track+":");
-			for (int j = 0; j < t.size(); j++) {
-				MidiEvent evt = t.get(j);
-				//if (evt.getTick() > 10_000L) break;
-				System.out.printf("Tick %08d: %s\n",evt.getTick(), MidiUtils.midiMessageToString(evt.getMessage()));
-			}
-		}
-*/
-
+		/*
+		 * // debug seq part 2:
+		 * System.out.println("  After processing");
+		 * Track[] trcks2 = this.sequence.getTracks();
+		 * for (int track = 0; track < trcks2.length; track++) {
+		 * //if (track != 0 && track != 1 && track != 2 && track != 13) continue;
+		 * Track t = trcks2[track];
+		 * System.out.println("\nTrack "+track+":");
+		 * for (int j = 0; j < t.size(); j++) {
+		 * MidiEvent evt = t.get(j);
+		 * //if (evt.getTick() > 10_000L) break;
+		 * System.out.printf("Tick %08d: %s\n",evt.getTick(),
+		 * MidiUtils.midiMessageToString(evt.getMessage()));
+		 * }
+		 * }
+		 */
 
 		composer = "";
 		/*
-		 * if (trackInfoList.get(0).hasName()) { title = trackInfoList.get(0).getName(); }
+		 * if (trackInfoList.get(0).hasName()) { title = trackInfoList.get(0).getName();
+		 * }
 		 */
 		title = fileName;
 		int dot = title.lastIndexOf('.');
@@ -250,10 +267,11 @@ public class SequenceInfo implements MidiConstants {
 			log.severe("Time signature does not match between SequenceInfo (" + getTimeSignature()
 					+ ") and SequenceDataCache (" + sequenceCache.getTimeSignature() + ").");
 		}
-    }
+	}
 
 	/**
-	 * This constructor ignores most of the data, as preview is only used for playback
+	 * This constructor ignores most of the data, as preview is only used for
+	 * playback
 	 */
 	private SequenceInfo(AbcExporter abcExporter, boolean useLotroInstruments)
 			throws InvalidMidiDataException, AbcConversionException {
@@ -262,12 +280,13 @@ public class SequenceInfo implements MidiConstants {
 		this.composer = metadata.getComposer();
 		this.title = metadata.getSongTitle();
 
-		Quad<List<ExportTrackInfo>, Sequence, PolyphonyHistogram, DissonanceDetector> result = abcExporter.exportToPreview(useLotroInstruments);
+		Quad<List<ExportTrackInfo>, Sequence, PolyphonyHistogram, DissonanceDetector> result = abcExporter
+				.exportToPreview(useLotroInstruments);
 
-        lastTrackInfos = result.first;
-        sequence = result.second;
-        histogram = result.third;
-        dissonance = result.fourth;
+		lastTrackInfos = result.first;
+		sequence = result.second;
+		histogram = result.third;
+		dissonance = result.fourth;
 		standard = MidiStandard.PREVIEW;
 		onlyFirstTrackTempos = true;
 		sequenceCache = new SequenceDataCache(sequence, standard,
@@ -292,7 +311,8 @@ public class SequenceInfo implements MidiConstants {
 			for (int jj = 0, sz1 = track.size(); jj < sz1; jj++) {
 				MidiEvent evt = track.get(jj);
 				long tick = evt.getTick();
-				if (tick > 0L) break;
+				if (tick > 0L)
+					break;
 				MidiMessage msg = evt.getMessage();
 				if (msg instanceof MetaMessage meta) {
 					if (meta.getType() == META_PORT_CHANGE) {
@@ -306,7 +326,9 @@ public class SequenceInfo implements MidiConstants {
 						}
 					} else if (meta.getType() == META_PORT_NAME) {
 						byte[] data = meta.getData();
-						log.warning(fileName+": Named port " + new String(data));//abc tools also use this line, no icu in jar, so dont call charset analyser.
+						log.warning(fileName + ": Named port " + new String(data));// abc tools also use this line, no
+																					// icu in jar, so dont call charset
+																					// analyser.
 					}
 				}
 			}
@@ -318,15 +340,19 @@ public class SequenceInfo implements MidiConstants {
 	 * Enforces monophonic-per-(port, channel, pitch) voice semantics so that every
 	 * NOTE_ON is matched by a NOTE_OFF on the same track before TrackInfo scans.
 	 *
-	 * A MIDI synth has one voice per (port, channel, pitch): a second NOTE_ON without
+	 * A MIDI synth has one voice per (port, channel, pitch): a second NOTE_ON
+	 * without
 	 * an intervening NOTE_OFF just retriggers that voice. But tracks are processed
-	 * per-track by TrackInfo, so two tracks sharing a (port, channel) -- the channel-10
-	 * tracks produced by drum separation, or type-1 files that reuse a channel -- can
+	 * per-track by TrackInfo, so two tracks sharing a (port, channel) -- the
+	 * channel-10
+	 * tracks produced by drum separation, or type-1 files that reuse a channel --
+	 * can
 	 * each hold the same pitch concurrently, which the synth never does. This pass
 	 * inserts the NOTE_OFFs that resolve those collisions and closes any still-open
 	 * note at its track's effective end.
 	 *
-	 * After this runs, fixupTrackLength2 can no longer leak active-note state across a
+	 * After this runs, fixupTrackLength2 can no longer leak active-note state
+	 * across a
 	 * dead track, because there are no never-closed notes left.
 	 *
 	 * Active only for usingNewMidiLayout >= 1: it changes note durations for
@@ -363,7 +389,8 @@ public class SequenceInfo implements MidiConstants {
 		// kind also serves as the equal-tick tie-break, so OFFs and EOTs are processed
 		// before ONs at the same tick (a real OFF must free the voice before a foreign
 		// ON at that tick is judged a collision).
-		record VEvent(long tick, int kind, int trackIdx, int channel, int pitch) {}
+		record VEvent(long tick, int kind, int trackIdx, int channel, int pitch) {
+		}
 
 		// The order of the numbers here matters for tiebreaking
 		final int KIND_OFF = 0;
@@ -407,7 +434,8 @@ public class SequenceInfo implements MidiConstants {
 			ownedByTrack.add(new HashSet<>());
 		}
 
-		record OffToInsert(int trackIdx, long tick, int channel, int pitch) {}
+		record OffToInsert(int trackIdx, long tick, int channel, int pitch) {
+		}
 		List<OffToInsert> offs = new ArrayList<>();
 
 		for (VEvent ve : events) {
@@ -470,9 +498,9 @@ public class SequenceInfo implements MidiConstants {
 		return (int) (key & 0xFF);
 	}
 
-    public List<ExportTrackInfo> getLastTrackInfos() {
-        return lastTrackInfos;
-    }
+	public List<ExportTrackInfo> getLastTrackInfos() {
+		return lastTrackInfos;
+	}
 
 	public String getFileName() {
 		return fileName;
@@ -546,7 +574,7 @@ public class SequenceInfo implements MidiConstants {
 				MidiEvent evt = t.get(j);
 				MidiMessage msg = evt.getMessage();
 				if (msg instanceof ShortMessage m) {
-                    if (m.getCommand() == ShortMessage.NOTE_ON) {
+					if (m.getCommand() == ShortMessage.NOTE_ON) {
 						if (evt.getTick() < firstNoteTick) {
 							firstNoteTick = evt.getTick();
 						}
@@ -567,7 +595,7 @@ public class SequenceInfo implements MidiConstants {
 				MidiEvent evt = t.get(j);
 				MidiMessage msg = evt.getMessage();
 				if (msg instanceof ShortMessage m) {
-                    if (m.getCommand() == ShortMessage.NOTE_OFF) {
+					if (m.getCommand() == ShortMessage.NOTE_OFF) {
 						if (evt.getTick() > lastNoteTick) {
 							lastNoteTick = evt.getTick();
 						}
@@ -583,12 +611,14 @@ public class SequenceInfo implements MidiConstants {
 	/**
 	 * Determine which MIDI variant we are dealing with.
 	 * 
-	 * Also figure out which channels GS, GM2 or XG has marked as drum channels. And if there are switches to drums in
+	 * Also figure out which channels GS, GM2 or XG has marked as drum channels. And
+	 * if there are switches to drums in
 	 * middle of some tracks.
 	 */
 	private void determineStandard(Sequence seq, String fileName) {
 
-		if (fileName.toLowerCase().endsWith(Util.ABC_FILE_EXTENSION) || fileName.toLowerCase().endsWith(Util.TXT_FILE_EXTENSION)) {
+		if (fileName.toLowerCase().endsWith(Util.ABC_FILE_EXTENSION)
+				|| fileName.toLowerCase().endsWith(Util.TXT_FILE_EXTENSION)) {
 			standard = MidiStandard.ABC;
 			return;
 		}
@@ -596,7 +626,8 @@ public class SequenceInfo implements MidiConstants {
 		// sysex GM reset: F0 7E dv 09 01 F7 (dv = device ID)
 		// sysex GM2 reset: F0 7E dv 09 03 F7 (dv = device ID)
 		// sysex Yamaha XG: F0 43 dv md 00 00 7E 00 F7 (dv = device ID, md = model id)
-		// sysex Roland GS: F0 41 dv 42 12 40 00 7F 00 sm F7 (dv = device ID, sm = checksum)
+		// sysex Roland GS: F0 41 dv 42 12 40 00 7F 00 sm F7 (dv = device ID, sm =
+		// checksum)
 
 		// sysex GS switch channel to/from drums:
 		// [ F0 41 dv 42 12 40 1x 15 mm sm F7 ]
@@ -606,21 +637,27 @@ public class SequenceInfo implements MidiConstants {
 		// dv: device ID
 
 		// sysex XG switch channel to/from drums:
-		// F0,43,dv,md,08,ch,07,xx,F7 (dv = device ID, md = model id, ch = channel, xx = drum mode)
+		// F0,43,dv,md,08,ch,07,xx,F7 (dv = device ID, md = model id, ch = channel, xx =
+		// drum mode)
 
 		// sysex XG drum part protect mode:
-		// F0 43 dv md 00 00 07 pp F7 (dv = device ID, md = model id, pp = 0 is off, 1 is on)
-		// If ON then only MSB 126/127 on chan #10. (unless by sysex bank change). XG Reset is counted as protect ON.
+		// F0 43 dv md 00 00 07 pp F7 (dv = device ID, md = model id, pp = 0 is off, 1
+		// is on)
+		// If ON then only MSB 126/127 on chan #10. (unless by sysex bank change). XG
+		// Reset is counted as protect ON.
 
 		// sysex XG MSB bank change:
-		// F0 43 dv md 08 nn 01 bb F7 (dv = device ID, md = model id, bb = MSB, nn = 0=non-chan#10 7F=chan#10)
+		// F0 43 dv md 08 nn 01 bb F7 (dv = device ID, md = model id, bb = MSB, nn =
+		// 0=non-chan#10 7F=chan#10)
 		// [However the real nn is just channel-number]
 
 		// sysex XG LSB bank change:
-		// F0 43 dv md 08 nn 02 bb F7 (dv = device ID, md = model id, bb = LSB, nn = default 0)
+		// F0 43 dv md 08 nn 02 bb F7 (dv = device ID, md = model id, bb = LSB, nn =
+		// default 0)
 
 		// sysex XG program change:
-		// F0 43 dv md 08 nn 03 pp F7 (dv = device ID, md = model id, pp = patch, nn = default 0)
+		// F0 43 dv md 08 nn 03 pp F7 (dv = device ID, md = model id, pp = patch, nn =
+		// default 0)
 
 		standard = MidiStandard.GM;
 
@@ -642,25 +679,27 @@ public class SequenceInfo implements MidiConstants {
 			for (int j = 0; j < track.size(); j++) {
 				MidiEvent evt = track.get(j);
 				MidiMessage msg = evt.getMessage();
-				if (evt.getTick() > 0L) break;
+				if (evt.getTick() > 0L)
+					break;
 				if (msg instanceof MetaMessage meta && meta.getType() == META_PORT_CHANGE) {
 					if (isSingleTrack && usingNewMidiLayout > 0) {
-                        try {
+						try {
 							// For single-track midi files we force the port to zero.
 							// Solves several issues later on
-                            meta.setMessage(META_PORT_CHANGE, new byte[]{0}, 1);
-                        } catch (InvalidMidiDataException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
+							meta.setMessage(META_PORT_CHANGE, new byte[] { 0 }, 1);
+						} catch (InvalidMidiDataException e) {
+							throw new RuntimeException(e);
+						}
+					}
 					byte[] data = meta.getData();
-					if (data.length > 0) currentPort = data[0] & 0xFF;
+					if (data.length > 0)
+						currentPort = data[0] & 0xFF;
 				}
 			}
 
-			TreeMap<Long, PatchEntry> bankAndPatchTrack = portBankAndPatchTrack.computeIfAbsent(currentPort, k -> new TreeMap<>());
+			TreeMap<Long, PatchEntry> bankAndPatchTrack = portBankAndPatchTrack.computeIfAbsent(currentPort,
+					k -> new TreeMap<>());
 
-			List<MidiEvent> phantomEvents = new ArrayList<>();
 			for (int j = 0; j < track.size(); j++) {
 				MidiEvent evt = track.get(j);
 				MidiMessage msg = evt.getMessage();
@@ -682,10 +721,11 @@ public class SequenceInfo implements MidiConstants {
 				}
 
 				if (msg instanceof SysexMessage sysex) {
-                    byte[] message = sysex.getMessage();
+					byte[] message = sysex.getMessage();
 
 					/*
-					 * StringBuilder sb = new StringBuilder(); for (byte b : message) { sb.append(String.format("%02X ",
+					 * StringBuilder sb = new StringBuilder(); for (byte b : message) {
+					 * sb.append(String.format("%02X ",
 					 * b)); } System.err.println("SYSEX on track "+i+": "+sb.toString());
 					 */
 
@@ -698,9 +738,11 @@ public class SequenceInfo implements MidiConstants {
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.XG;
 						} else if (MidiStandard.GS == standard && evt.getTick() == lastResetTick) {
-							log.info("They are at same tick. Statistically bigger chance its a GS, so not switching to XG.");
+							log.info(
+									"They are at same tick. Statistically bigger chance its a GS, so not switching to XG.");
 						} else if (MidiStandard.GM2 == standard && evt.getTick() == lastResetTick) {
-							log.info("They are at same tick. Statistically bigger chance its a XG, so switching to that.");
+							log.info(
+									"They are at same tick. Statistically bigger chance its a XG, so switching to that.");
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.XG;
 						}
@@ -724,7 +766,8 @@ public class SequenceInfo implements MidiConstants {
 							lastResetTick = evt.getTick();
 							standard = MidiStandard.GM2;
 						} else if (evt.getTick() == lastResetTick && MidiStandard.GM != standard) {
-							log.info("They are at same tick. Statistically bigger chance its not a GM2, so not switching standard.");
+							log.info(
+									"They are at same tick. Statistically bigger chance its not a GM2, so not switching standard.");
 						}
 						ExtensionMidiInstrument.getInstance();
 						// System.err.println("MIDI GM2 Reset, tick "+evt.getTick());
@@ -757,7 +800,8 @@ public class SequenceInfo implements MidiConstants {
 						int channel = message[5] & 0xFF;
 						int setup = message[7] & 0xFF;
 						if (channel < CHANNEL_COUNT) {
-							// From Tyros 1 data doc: part10=0x02, other parts=0x00. Korg EX-20 say this is channel.
+							// From Tyros 1 data doc: part10=0x02, other parts=0x00. Korg EX-20 say this is
+							// channel.
 							// TODO: Drum Setup Reset sysex.
 							// Sure looks like Korg has it correct, at least for pre Tyros XG standard.
 							if (setup == 0) {
@@ -772,7 +816,7 @@ public class SequenceInfo implements MidiConstants {
 							} else {
 								type = "Invalid setup: " + setup;
 							}
-							log.fine("Yamaha XG setting channel #"+channel+" to "+type);
+							log.fine("Yamaha XG setting channel #" + channel + " to " + type);
 
 							if (usingNewMidiLayout >= 1 && setup <= 5) {
 								boolean isDrum = "Drums".equals(type) || type.startsWith("Drums Setup");
@@ -793,14 +837,12 @@ public class SequenceInfo implements MidiConstants {
 									ShortMessage fakeMsb = new ShortMessage();
 									fakeMsb.setMessage(ShortMessage.CONTROL_CHANGE, channel, BANK_SELECT_MSB, msbValue);
 									MidiEvent msbEvt = new MidiEvent(fakeMsb, evt.getTick());
-									phantomEvents.add(msbEvt);
 									entry.bank.add(msbEvt);
 
 									// Standard Kit / Grand Piano
 									ShortMessage fakePc = new ShortMessage();
 									fakePc.setMessage(ShortMessage.PROGRAM_CHANGE, channel, 0, 0);
 									MidiEvent pcEvt = new MidiEvent(fakePc, evt.getTick());
-									phantomEvents.add(pcEvt);
 									entry.patch.add(pcEvt);
 								} catch (InvalidMidiDataException e) {
 									log.warning("Failed to inject phantom drum bank change");
@@ -811,17 +853,21 @@ public class SequenceInfo implements MidiConstants {
 							&& (message[3] & 0xFF) == 0x4C
 							&& (message[4] & 0xFF) == 0x00 && (message[5] & 0xFF) == 0x00 && (message[6] & 0xFF) == 0x07
 							&& (message[8] & 0xFF) == 0xF7) {
-						// TODO: This is default ON by a XG reset. It prevent bank changes to drum channels that are not
-						//       126/127 MSB.
-						//       Ignoring this sysex as I have tested 130,000 midi files and none of them had an OFF,
-						//       so its super rare.
+						// TODO: This is default ON by a XG reset. It prevent bank changes to drum
+						// channels that are not
+						// 126/127 MSB.
+						// Ignoring this sysex as I have tested 130,000 midi files and none of them had
+						// an OFF,
+						// so its super rare.
 						log.warning(
 								fileName + ": Yamaha XG Drum Part Protect mode " + (message[7] == 0 ? "OFF" : "ON"));
 					} else if (message.length == 9 && (message[0] & 0xFF) == 0xF0 && (message[1] & 0xFF) == 0x43
-							&& (message[3] & 0xFF) == 0x4C // this check can change the listed instr, but that does not break back compat
+							&& (message[3] & 0xFF) == 0x4C // this check can change the listed instr, but that does not
+															// break back compat
 							&& (message[4] & 0xFF) == 0x08 && (message[8] & 0xFF) == 0xF7) {
 						// XG bank/patch change
-						// We do not check for standard here cause it is later put into yamaha bank changes and only
+						// We do not check for standard here cause it is later put into yamaha bank
+						// changes and only
 						// Used in XG standard.
 						PatchEntry entry = null;
 						entry = bankAndPatchTrack.get(evt.getTick());
@@ -833,13 +879,13 @@ public class SequenceInfo implements MidiConstants {
 							entry.sysex.add(evt);
 						}
 						/*
-						if ((message[3] & 0xFF) != 0x4C) {
-							log.severe("Yamaha XG bank select without 0x4C !!! "+fileName);
-						}
-						*/
+						 * if ((message[3] & 0xFF) != 0x4C) {
+						 * log.severe("Yamaha XG bank select without 0x4C !!! "+fileName);
+						 * }
+						 */
 					}
 				} else if (msg instanceof ShortMessage m) {
-                    int cmd = m.getCommand();
+					int cmd = m.getCommand();
 
 					if (cmd == ShortMessage.PROGRAM_CHANGE) {
 						PatchEntry entry = null;
@@ -864,22 +910,15 @@ public class SequenceInfo implements MidiConstants {
 					}
 				}
 			}
-
-			/*
-			This can potentially override existing bank/patch change if they are at same tick. Therefore we comment this.
-			for (MidiEvent pEvt : phantomEvents) {
-				track.add(pEvt);
-			}
-			*/
 		}
-		
+
 		/*
-		  yamahaBankAndPatchChanges (XG) & mmaBankAndPatchChanges (GM2):
-
-		  0 = chromatic voice
-		  1 = Has switched to drums, but patch not selected yet.
-		  2 = drum
-
+		 * yamahaBankAndPatchChanges (XG) & mmaBankAndPatchChanges (GM2):
+		 * 
+		 * 0 = chromatic voice
+		 * 1 = Has switched to drums, but patch not selected yet.
+		 * 2 = drum
+		 * 
 		 */
 		final int CHROMATIC = 0;
 		final int DRUMS_UNKNOWN_PATCH = 1;
@@ -904,8 +943,10 @@ public class SequenceInfo implements MidiConstants {
 		}
 
 		/*
-		 * Iterate again, but this time in order of ticks no matter which track the events come from. This time we find
-		 * where there is changes from rhythm to chromatic voices and the other way around. We need that for determining
+		 * Iterate again, but this time in order of ticks no matter which track the
+		 * events come from. This time we find
+		 * where there is changes from rhythm to chromatic voices and the other way
+		 * around. We need that for determining
 		 * how to separate drum tracks and which tracks to mark as drum tracks.
 		 * 
 		 */
@@ -917,10 +958,12 @@ public class SequenceInfo implements MidiConstants {
 			for (PatchEntry entry : bankAndPatchTrack.values()) {
 				List<MidiEvent> masterList = new ArrayList<>();
 
-				// The order here is important, patch must be last, since not all MIDI files adhere to standard of certain
+				// The order here is important, patch must be last, since not all MIDI files
+				// adhere to standard of certain
 				// time separation between these
 				// events:
-				// Not sure if sysex bank/patch change have higher priority than Control Change events. But giving it lowest
+				// Not sure if sysex bank/patch change have higher priority than Control Change
+				// events. But giving it lowest
 				// priority for now.
 				masterList.addAll(entry.sysex);
 				masterList.addAll(entry.bank);
@@ -930,24 +973,30 @@ public class SequenceInfo implements MidiConstants {
 					MidiMessage msg = evt.getMessage();
 					if (msg instanceof SysexMessage sysex) {
 						byte[] message = sysex.getMessage();
-						// we already know that this sysex is a XG bank/patch/mode change, so no need for if statement.
+						// we already know that this sysex is a XG bank/patch/mode change, so no need
+						// for if statement.
 						String bank = "";
 						int addressType = message[6] & 0xFF;
-						if (addressType == 1) bank = "MSB";
-						else if (addressType == 2) bank = "LSB";
-						else if (addressType == 3) bank = "Patch";
-						else if (addressType == 7) bank = "ChannelMode";
+						if (addressType == 1)
+							bank = "MSB";
+						else if (addressType == 2)
+							bank = "LSB";
+						else if (addressType == 3)
+							bank = "Patch";
+						else if (addressType == 7)
+							bank = "ChannelMode";
 
 						int ch = message[5] & 0xFF;
 						if (!bank.isEmpty() && ch < CHANNEL_COUNT && message[7] < 128 && message[7] >= 0) {
-							// System.err.println(fileName+": Yamaha XG Sysex "+bank+" set to "+message[7]+" for channel
+							// System.err.println(fileName+": Yamaha XG Sysex "+bank+" set to "+message[7]+"
+							// for channel
 							// "+message[5]);
 							if ("ChannelMode".equals(bank)) {
 								if (usingNewMidiLayout >= 1) {
 									if (message[7] > 0) {
 										// Switching to Drums
 										if (yamahaBankAndPatchChanges[ch] < DRUMS)
-												yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
+											yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
 									} else {
 										// Switching back to Melodic
 										yamahaBankAndPatchChanges[ch] = CHROMATIC;
@@ -955,12 +1004,14 @@ public class SequenceInfo implements MidiConstants {
 									}
 								}
 							} else if ("MSB".equals(bank)) {
-								if (message[7] == 126 || message[7] == 127) {// 64 is chromatic effects, so not testing for
+								if (message[7] == 126 || message[7] == 127) {// 64 is chromatic effects, so not testing
+																				// for
 									// that.
 									if (usingNewMidiLayout == 0) {
 										yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
 									} else {
-										if (yamahaBankAndPatchChanges[ch] < DRUMS) yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
+										if (yamahaBankAndPatchChanges[ch] < DRUMS)
+											yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
 									}
 								} else {
 									yamahaBankAndPatchChanges[ch] = CHROMATIC;
@@ -968,9 +1019,11 @@ public class SequenceInfo implements MidiConstants {
 							} else if ("Patch".equals(bank)) {
 								if (yamahaBankAndPatchChanges[ch] > CHROMATIC) {
 									yamahaBankAndPatchChanges[ch] = DRUMS;
-									// Apply standard bank changes across all active ports to prevent breaking old files
+									// Apply standard bank changes across all active ports to prevent breaking old
+									// files
 									if (usingNewMidiLayout == 0) {
-										for (ArrayList<TreeMap<Long, Boolean>> portChannels : yamahaDrumSwitches.values()) {
+										for (ArrayList<TreeMap<Long, Boolean>> portChannels : yamahaDrumSwitches
+												.values()) {
 											portChannels.get(ch).put(evt.getTick(), true);
 										}
 									} else {
@@ -979,7 +1032,8 @@ public class SequenceInfo implements MidiConstants {
 									// System.err.println(" XG drums in channel "+(ch+1));
 								} else if (yamahaBankAndPatchChanges[ch] == CHROMATIC) {
 									if (usingNewMidiLayout == 0) {
-										for (ArrayList<TreeMap<Long, Boolean>> portChannels : yamahaDrumSwitches.values()) {
+										for (ArrayList<TreeMap<Long, Boolean>> portChannels : yamahaDrumSwitches
+												.values()) {
 											portChannels.get(ch).put(evt.getTick(), false);
 										}
 									} else {
@@ -1003,7 +1057,8 @@ public class SequenceInfo implements MidiConstants {
 								} else {
 									yamahaDrumSwitches.get(port).get(ch).put(evt.getTick(), true);
 								}
-								// if (ch == 9) System.err.println("XG channel "+ch+" changed to drum kit "+m.getData1()+"
+								// if (ch == 9) System.err.println("XG channel "+ch+" changed to drum kit
+								// "+m.getData1()+"
 								// at tick "+evt.getTick());
 							} else if (yamahaBankAndPatchChanges[ch] == CHROMATIC) {
 								if (usingNewMidiLayout == 0) {
@@ -1013,7 +1068,8 @@ public class SequenceInfo implements MidiConstants {
 								} else {
 									yamahaDrumSwitches.get(port).get(ch).put(evt.getTick(), false);
 								}
-								// if (ch == 9) System.err.println("XG channel "+ch+" changed to voice "+m.getData1()+" at
+								// if (ch == 9) System.err.println("XG channel "+ch+" changed to voice
+								// "+m.getData1()+" at
 								// tick "+evt.getTick());
 							}
 							if (mmaBankAndPatchChanges[ch] > CHROMATIC) {
@@ -1034,7 +1090,8 @@ public class SequenceInfo implements MidiConstants {
 								} else {
 									mmaDrumSwitches.get(port).get(ch).put(evt.getTick(), false);
 								}
-								// System.err.println(" GM2 channel "+ch+" changed voice at tick "+evt.getTick());
+								// System.err.println(" GM2 channel "+ch+" changed voice at tick
+								// "+evt.getTick());
 							}
 						} else if (cmd == ShortMessage.CONTROL_CHANGE) {
 							switch (m.getData1()) {
@@ -1046,12 +1103,14 @@ public class SequenceInfo implements MidiConstants {
 												// Blocked. Do not change the state.
 											} else {
 												// Valid drum MSB.
-												if (yamahaBankAndPatchChanges[ch] < DRUMS) yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
+												if (yamahaBankAndPatchChanges[ch] < DRUMS)
+													yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
 											}
 										} else {
 											// In XG hardware, melodic tracks allow MSB 126/127.
 											if (m.getData2() == 127 || m.getData2() == 126) {
-												if (yamahaBankAndPatchChanges[ch] < DRUMS) yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
+												if (yamahaBankAndPatchChanges[ch] < DRUMS)
+													yamahaBankAndPatchChanges[ch] = DRUMS_UNKNOWN_PATCH;
 											} else {
 												yamahaBankAndPatchChanges[ch] = CHROMATIC;
 											}
@@ -1101,7 +1160,7 @@ public class SequenceInfo implements MidiConstants {
 	 * This holds info to sequence after drums have been separated into own tracks.
 	 */
 	private boolean isYamahaDrum(int port, int channel) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (yamahaDrumChannels.get(port) == null) {
 			yamahaDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			yamahaDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -1110,7 +1169,7 @@ public class SequenceInfo implements MidiConstants {
 	}
 
 	private void putYamahaDrum(int port, int channel, Boolean drum) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (yamahaDrumChannels.get(port) == null) {
 			yamahaDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			yamahaDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -1123,7 +1182,7 @@ public class SequenceInfo implements MidiConstants {
 	 * This holds info to sequence after drums have been separated into own tracks.
 	 */
 	private boolean isRolandDrum(int port, int channel) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (rolandDrumChannels.get(port) == null) {
 			rolandDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			rolandDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -1132,7 +1191,7 @@ public class SequenceInfo implements MidiConstants {
 	}
 
 	private void putRolandDrum(int port, int channel, Boolean drum) {
-		port = usingNewMidiLayout==0?0:port;
+		port = usingNewMidiLayout == 0 ? 0 : port;
 		if (rolandDrumChannels.get(port) == null) {
 			rolandDrumChannels.put(port, new ArrayList<>(Collections.nCopies(CHANNEL_COUNT_ABC, false)));
 			rolandDrumChannels.get(port).set(DRUM_CHANNEL, true);
@@ -1149,10 +1208,10 @@ public class SequenceInfo implements MidiConstants {
 	public boolean convertToType1(Sequence song) {
 		if (song.getTracks().length == 1 && MidiStandard.ABC != standard) {
 			Track track0 = song.getTracks()[0];
-			Track[] tracks = new Track[CHANNEL_COUNT+1];
+			Track[] tracks = new Track[CHANNEL_COUNT + 1];
 
-            Track newTrack0 = song.createTrack();
-            tracks[0] = newTrack0;
+			Track newTrack0 = song.createTrack();
+			tracks[0] = newTrack0;
 
 			MidiEvent endOfTrack = null;
 			int j = track0.size() - 1;
@@ -1166,9 +1225,10 @@ public class SequenceInfo implements MidiConstants {
 				}
 				j--;
 			}
-            boolean eotWasMissing = endOfTrack == null;
+			boolean eotWasMissing = endOfTrack == null;
 			if (eotWasMissing) {
-				// This midi has no EOT, which is in violation of midi standard, so we make one at last tick.
+				// This midi has no EOT, which is in violation of midi standard, so we make one
+				// at last tick.
 				endOfTrack = MidiFactory.createEndOfTrackEvent(track0.get(track0.size() - 1).getTick());
 			}
 
@@ -1178,31 +1238,31 @@ public class SequenceInfo implements MidiConstants {
 				MidiEvent evt = track0.get(i);
 				if (evt.getMessage() instanceof ShortMessage) {
 					int chan = ((ShortMessage) evt.getMessage()).getChannel();
-					if (tracks[chan+1] == null) {
-						tracks[chan+1] = song.createTrack();
+					if (tracks[chan + 1] == null) {
+						tracks[chan + 1] = song.createTrack();
 
-                        // so that track don't share EOT event so TrackInfo cannot manipulate them
-                        // individually, we create a new EOT event for each track.
-                        MidiEvent newEOT = new MidiEvent(endOfTrack.getMessage(), endOfTrack.getTick());
-                        tracks[chan+1].add(newEOT);
+						// so that track don't share EOT event so TrackInfo cannot manipulate them
+						// individually, we create a new EOT event for each track.
+						MidiEvent newEOT = new MidiEvent(endOfTrack.getMessage(), endOfTrack.getTick());
+						tracks[chan + 1].add(newEOT);
 
 						String trackName = "Track " + trackNumber;
- 
+
 						trackNumber++;
-						tracks[chan+1].add(MidiFactory.createTrackNameEvent(trackName));
+						tracks[chan + 1].add(MidiFactory.createTrackNameEvent(trackName));
 					}
-					tracks[chan+1].add(evt);
+					tracks[chan + 1].add(evt);
 				} else {
-                    newTrack0.add(evt);
-                }
+					newTrack0.add(evt);
+				}
 				i++;
 			}
 
-            if (eotWasMissing) {
-                newTrack0.add(endOfTrack);
-            }
+			if (eotWasMissing) {
+				newTrack0.add(endOfTrack);
+			}
 
-            song.deleteTrack(track0);
+			song.deleteTrack(track0);
 			return true;
 		}
 		return false;
@@ -1213,16 +1273,16 @@ public class SequenceInfo implements MidiConstants {
 	 */
 	public Sequence separateDrumTracks(Sequence song) {
 		/*
-			Since commit 1104b2d9 there have been a bug in this method due to
-			that only 'modified' was used and not 'trackModified'.
-			My analysis of this bug indicates the bug is harmless due to
-			users won't see the assert statement and the notes in
-			question will just stay on their track.
-			So I am fixing the bug for v4.6.2, and this flag can be used if
-			I really want to preserve the bug for projects between that commit
-			and this version. Then it will have to be true to recreate the bug,
-			and it has to be stored in the project file.
-			But for now we keep it false, which will just fix the bug.
+		 * Since commit 1104b2d9 there have been a bug in this method due to
+		 * that only 'modified' was used and not 'trackModified'.
+		 * My analysis of this bug indicates the bug is harmless due to
+		 * users won't see the assert statement and the notes in
+		 * question will just stay on their track.
+		 * So I am fixing the bug for v4.6.2, and this flag can be used if
+		 * I really want to preserve the bug for projects between that commit
+		 * and this version. Then it will have to be true to recreate the bug,
+		 * and it has to be stored in the project file.
+		 * But for now we keep it false, which will just fix the bug.
 		 */
 		boolean useLegacyLogic = false;
 
@@ -1230,28 +1290,28 @@ public class SequenceInfo implements MidiConstants {
 			return song;
 		}
 
-        // Create new Sequence to avoid O(N^2) removal
-        Sequence newSeq;
-        try {
-            newSeq = new Sequence(song.getDivisionType(), song.getResolution());
-        } catch (InvalidMidiDataException e) {
-            return song;
-        }
+		// Create new Sequence to avoid O(N^2) removal
+		Sequence newSeq;
+		try {
+			newSeq = new Sequence(song.getDivisionType(), song.getResolution());
+		} catch (InvalidMidiDataException e) {
+			return song;
+		}
 
-        Track[] oldTracks = song.getTracks();
+		Track[] oldTracks = song.getTracks();
 
-        Track[] newMainTracks = new Track[oldTracks.length];
-        for (int i = 0; i < oldTracks.length; i++) {
-            newMainTracks[i] = newSeq.createTrack();
-        }
+		Track[] newMainTracks = new Track[oldTracks.length];
+		for (int i = 0; i < oldTracks.length; i++) {
+			newMainTracks[i] = newSeq.createTrack();
+		}
 
-        boolean modified = false;
+		boolean modified = false;
 
 		for (int i = 0; i < oldTracks.length; i++) {
 			boolean trackModified = false;
 
-            Track oldTrack = oldTracks[i];
-            Track mainTrack = newMainTracks[i];
+			Track oldTrack = oldTracks[i];
+			Track mainTrack = newMainTracks[i];
 
 			// Find the port event on this track
 			// We do NOT build the portMap here, that is done after seperation.
@@ -1259,191 +1319,215 @@ public class SequenceInfo implements MidiConstants {
 			int port = 0;
 			for (int j = 0; j < oldTrack.size(); j++) {
 				MidiEvent evt = oldTrack.get(j);
-				if (evt.getTick() > 0L) break;
+				if (evt.getTick() > 0L)
+					break;
 				if (evt.getMessage() instanceof MetaMessage meta && meta.getType() == META_PORT_CHANGE) {
 					portEvent = evt;
 					byte[] data = meta.getData();
-					if (data.length > 0) port = data[0] & 0xFF;
-					if (port > 127) log.warning(fileName+": Port number out of range: "+port+". File might not be interpreted correctly.");
+					if (data.length > 0)
+						port = data[0] & 0xFF;
+					if (port > 127)
+						log.warning(fileName + ": Port number out of range: " + port
+								+ ". File might not be interpreted correctly.");
 					break;
 				}
 			}
 
 			port = usingNewMidiLayout == 0 ? (standard == MidiStandard.GM ? port : 0) : port;
 
-            int drumsGS = 0;
-            int drumsXG = 0;
-            int drumsGM2 = 0;
-            int drumsGM = 0;
+			int drumsGS = 0;
+			int drumsXG = 0;
+			int drumsGM2 = 0;
+			int drumsGM = 0;
 
-            int drumsExt10 = 0;// Extension drum notes on default-drum-channel
-            int drumsExtX = 0;// Extension drum notes on non-default-drum-channel
+			int drumsExt10 = 0;// Extension drum notes on default-drum-channel
+			int drumsExtX = 0;// Extension drum notes on non-default-drum-channel
 
-            int notes = 0;// Chromatic notes
-            int notes10 = 0;// Chromatic notes on default-drum-channel
-            int notesX = 0;// Chromatic notes on non-default-drum-channel
+			int notes = 0;// Chromatic notes
+			int notes10 = 0;// Chromatic notes on default-drum-channel
+			int notesX = 0;// Chromatic notes on non-default-drum-channel
 
-            for (int j = 0; j < oldTrack.size(); j++) {
-                MidiEvent evt = oldTrack.get(j);
-                MidiMessage msg = evt.getMessage();
+			for (int j = 0; j < oldTrack.size(); j++) {
+				MidiEvent evt = oldTrack.get(j);
+				MidiMessage msg = evt.getMessage();
 
-                if (!(msg instanceof ShortMessage m)) {
-                    continue;
-                }
+				if (!(msg instanceof ShortMessage m)) {
+					continue;
+				}
 
-                int chan = m.getChannel();
+				int chan = m.getChannel();
 
-                if (m.getCommand() != ShortMessage.NOTE_ON) {
-                    continue;
-                }
+				if (m.getCommand() != ShortMessage.NOTE_ON) {
+					continue;
+				}
 
-                if (isDrumGM(chan)) {
-                    drumsGM = 1;
-                } else if (isDrumGS(port, chan)) {
-                    drumsGS = 1;
-                } else if (isDrumXG(evt, port, chan)) {
-                    drumsXG = 1;
-                } else if (isDrumGM2(evt, port, chan)) {
-                    drumsGM2 = 1;
-                } else {
-                    notes = 1;
-                    if (chan == DRUM_CHANNEL)
-                        notes10 = 1;
-                    else
-                        notesX = 1;
-                }
+				if (isDrumGM(chan)) {
+					drumsGM = 1;
+				} else if (isDrumGS(port, chan)) {
+					drumsGS = 1;
+				} else if (isDrumXG(evt, port, chan)) {
+					drumsXG = 1;
+				} else if (isDrumGM2(evt, port, chan)) {
+					drumsGM2 = 1;
+				} else {
+					notes = 1;
+					if (chan == DRUM_CHANNEL)
+						notes10 = 1;
+					else
+						notesX = 1;
+				}
 
-                if (drumsGS + drumsXG + drumsGM2 > 0) {
-                    if (chan == DRUM_CHANNEL) drumsExt10 = 1;
-                    else drumsExtX = 1;
-                }
-            }
+				if (drumsGS + drumsXG + drumsGM2 > 0) {
+					if (chan == DRUM_CHANNEL)
+						drumsExt10 = 1;
+					else
+						drumsExtX = 1;
+				}
+			}
 
+			/*
+			 * I had to design this carefully in high degree to not mess up v2.5.0 Projects
+			 * too much.
+			 *
+			 * If channel 10 drums plus brand drums. Then v2.5.0 would have made new track
+			 * for channel 10. So in that
+			 * case if no real melodic notes make brand drums stay and funnel channel 10
+			 * into new channel even if
+			 * standard is not GM.
+			 *
+			 * If notes+channel 10 drums+brand drums, make notes stay, funnel the others
+			 * into own 2 tracks. channel 10
+			 * drums before brand.
+			 *
+			 * If notes on channel 10 and notes that are not channel 10, then separate them
+			 * also, to keep backwards compat
+			 * with v2.5.0 projects.
+			 *
+			 */
 
-            /*
-             * I had to design this carefully in high degree to not mess up v2.5.0 Projects too much.
-             *
-             * If channel 10 drums plus brand drums. Then v2.5.0 would have made new track for channel 10. So in that
-             * case if no real melodic notes make brand drums stay and funnel channel 10 into new channel even if
-             * standard is not GM.
-             *
-             * If notes+channel 10 drums+brand drums, make notes stay, funnel the others into own 2 tracks. channel 10
-             * drums before brand.
-             *
-             * If notes on channel 10 and notes that are not channel 10, then separate them also, to keep backwards compat
-             * with v2.5.0 projects.
-             *
-             */
+			Track drumTrack = null;
+			Track noteTrack = null;
+			Track brandDrumTrack = null;
 
-            Track drumTrack = null;
-            Track noteTrack = null;
-            Track brandDrumTrack = null;
-
-            if (drumsGS + drumsXG + drumsGM2 + notes + drumsGM > 1 || (drumsExt10 + drumsExtX > 1) || (notes10 + notesX > 1)) {
-                modified = true;
+			if (drumsGS + drumsXG + drumsGM2 + notes + drumsGM > 1 || (drumsExt10 + drumsExtX > 1)
+					|| (notes10 + notesX > 1)) {
+				modified = true;
 				trackModified = true;
 
-                if (notes == 1) {
-                    if (drumsGM == 1) {
-                        drumTrack = newSeq.createTrack();
-                        drumTrack.add(MidiFactory.createTrackNameEvent(ExtensionMidiInstrument.TRACK_NAME_DRUM_GM));
-						if (portEvent != null) drumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
-                        //System.err.println("Drum and Chromatic notes in same track. Create ch10 GM Drum track. From "+i);
-                    }
-                    if (notes10 + notesX > 1) {
-                        noteTrack = newSeq.createTrack();
-                        noteTrack.add(MidiFactory.createTrackNameEvent("Track " + i + "+"));
-						if (portEvent != null) noteTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
-                        //System.err.println("Chromatic notes in channel 10. Create chromatic ch10 track. From " + i);
-                    }
-                    if (drumsXG + drumsGS + drumsGM2 > 0) {
-                        brandDrumTrack = createBrandDrumTrack(drumsGS, drumsXG, drumsGM2, newSeq);
-						if (portEvent != null) brandDrumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
-                        //System.err.println("Drum and Chromatic notes in same track. Create EXT Drum track. From "+i);
-                    }
-                } else {
-                    // Only drum notes in this track
-                    if (drumsExt10 == 1) {
-                        // Maestro v2.5.0 would have separated these, so we do the same.
-                        brandDrumTrack = createBrandDrumTrack(drumsGS, drumsXG, drumsGM2, newSeq);
-						if (portEvent != null) brandDrumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
-                        //System.err.println("EXT Drum notes in ch10 and in other channels. Create EXT Drum track. From "+i);
-                    }
-                    assert drumsGM == 0;
-                }
-            }
+				if (notes == 1) {
+					if (drumsGM == 1) {
+						drumTrack = newSeq.createTrack();
+						drumTrack.add(MidiFactory.createTrackNameEvent(ExtensionMidiInstrument.TRACK_NAME_DRUM_GM));
+						if (portEvent != null)
+							drumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
+						// System.err.println("Drum and Chromatic notes in same track. Create ch10 GM
+						// Drum track. From "+i);
+					}
+					if (notes10 + notesX > 1) {
+						noteTrack = newSeq.createTrack();
+						noteTrack.add(MidiFactory.createTrackNameEvent("Track " + i + "+"));
+						if (portEvent != null)
+							noteTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
+						// System.err.println("Chromatic notes in channel 10. Create chromatic ch10
+						// track. From " + i);
+					}
+					if (drumsXG + drumsGS + drumsGM2 > 0) {
+						brandDrumTrack = createBrandDrumTrack(drumsGS, drumsXG, drumsGM2, newSeq);
+						if (portEvent != null)
+							brandDrumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
+						// System.err.println("Drum and Chromatic notes in same track. Create EXT Drum
+						// track. From "+i);
+					}
+				} else {
+					// Only drum notes in this track
+					if (drumsExt10 == 1) {
+						// Maestro v2.5.0 would have separated these, so we do the same.
+						brandDrumTrack = createBrandDrumTrack(drumsGS, drumsXG, drumsGM2, newSeq);
+						if (portEvent != null)
+							brandDrumTrack.add(new MidiEvent(portEvent.getMessage(), portEvent.getTick()));
+						// System.err.println("EXT Drum notes in ch10 and in other channels. Create EXT
+						// Drum track. From "+i);
+					}
+					assert drumsGM == 0;
+				}
+			}
 
-            // Mixed track:
-            for (int j = 0; j < oldTrack.size(); j++) {
-                MidiEvent evt = oldTrack.get(j);
-                MidiMessage msg = evt.getMessage();
+			// Mixed track:
+			for (int j = 0; j < oldTrack.size(); j++) {
+				MidiEvent evt = oldTrack.get(j);
+				MidiMessage msg = evt.getMessage();
 				long tick = evt.getTick();
-                boolean moved = false;
+				boolean moved = false;
 
-                if (msg instanceof ShortMessage smsg && (useLegacyLogic && modified || !useLegacyLogic && trackModified)) {
-                    int chan = smsg.getChannel();
-                    if (drumTrack != null && drumsGM == 1 && chan == DRUM_CHANNEL) {
-                        // GM drum note split into new track
-                        drumTrack.add(evt);
-                        moved = true;
-                    } else if (brandDrumTrack != null && drumsGS == 1 && (notes == 1 || chan == DRUM_CHANNEL)
-                            && isRolandDrum(port,chan)) {
-                        // GS drum note split into new track because either:
-                        // - to avoid mixing with chromatics.
-                        // - its on ch10, which v2.5.0 would also have split into new track.
-                        brandDrumTrack.add(evt);
-                        moved = true;
-                    } else if (brandDrumTrack != null && drumsXG == 1 && (notes == 1 || chan == DRUM_CHANNEL)
-                            && yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
-                            && yamahaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue()) {
-                        // XG drum note split into new track because either:
-                        // - to avoid mixing with chromatics.
-                        // - its on ch10, which v2.5.0 would also have split into new track.
-                        brandDrumTrack.add(evt);
-                        moved = true;
-                    } else if (brandDrumTrack != null && drumsGM2 == 1 && (notes == 1 || chan == DRUM_CHANNEL)
-                            && mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
-                            && mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue()) {
-                        // GM2 drum note split into new track because either:
-                        // - to avoid mixing with chromatics.
-                        // - its on ch10, which v2.5.0 would also have split into new track.
-                        brandDrumTrack.add(evt);
-                        moved = true;
-                    } else if ((drumsGS == 1 && isRolandDrum(port,chan))
-                            || (drumsXG == 1 && yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
-                            && yamahaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue())
-                            || (drumsGM2 == 1 && mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
-                            && mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue())) {
-                        // These non-channel-10 GS/XG/GM2 drum notes stay in the track.
-                        // The chromatic notes will never enter here as
-                        // 'notes' will be 1 when they are present,
-                        // and therefore no drum notes will reach last IF statement.
-                        assert useLegacyLogic || chan != DRUM_CHANNEL : "Ch10 extension drum note refuse to leave track!" +
-								"\n drumsGS="+drumsGS+" drumsGM2="+drumsGM2+" drumsXG="+drumsXG+" drumsGM="+drumsGM
-								+"\n notes="+notes+" channel="+chan+" drumsExt10="+drumsExt10+" drumsExtX="+drumsExtX
-								+"\n notes10="+notes10 +" notesX="+ notesX
-								+" isGSDrumChannel="+(isRolandDrum(port,chan))
-								+" isXGdrum="+(yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+				if (msg instanceof ShortMessage smsg
+						&& (useLegacyLogic && modified || !useLegacyLogic && trackModified)) {
+					int chan = smsg.getChannel();
+					if (drumTrack != null && drumsGM == 1 && chan == DRUM_CHANNEL) {
+						// GM drum note split into new track
+						drumTrack.add(evt);
+						moved = true;
+					} else if (brandDrumTrack != null && drumsGS == 1 && (notes == 1 || chan == DRUM_CHANNEL)
+							&& isRolandDrum(port, chan)) {
+						// GS drum note split into new track because either:
+						// - to avoid mixing with chromatics.
+						// - its on ch10, which v2.5.0 would also have split into new track.
+						brandDrumTrack.add(evt);
+						moved = true;
+					} else if (brandDrumTrack != null && drumsXG == 1 && (notes == 1 || chan == DRUM_CHANNEL)
+							&& yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+							&& yamahaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue()) {
+						// XG drum note split into new track because either:
+						// - to avoid mixing with chromatics.
+						// - its on ch10, which v2.5.0 would also have split into new track.
+						brandDrumTrack.add(evt);
+						moved = true;
+					} else if (brandDrumTrack != null && drumsGM2 == 1 && (notes == 1 || chan == DRUM_CHANNEL)
+							&& mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+							&& mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue()) {
+						// GM2 drum note split into new track because either:
+						// - to avoid mixing with chromatics.
+						// - its on ch10, which v2.5.0 would also have split into new track.
+						brandDrumTrack.add(evt);
+						moved = true;
+					} else if ((drumsGS == 1 && isRolandDrum(port, chan))
+							|| (drumsXG == 1 && yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
 									&& yamahaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue())
-								+" isGM2drum="+(mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
-									&& mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue());
-                    } else if (noteTrack != null && chan == DRUM_CHANNEL) {
-                        // Chromatic note on ch10. Split it into new track.
-                        noteTrack.add(evt);
-                        moved = true;
-                    }
-                }
+							|| (drumsGM2 == 1 && mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+									&& mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue())) {
+						// These non-channel-10 GS/XG/GM2 drum notes stay in the track.
+						// The chromatic notes will never enter here as
+						// 'notes' will be 1 when they are present,
+						// and therefore no drum notes will reach last IF statement.
+						assert useLegacyLogic || chan != DRUM_CHANNEL
+								: "Ch10 extension drum note refuse to leave track!" +
+										"\n drumsGS=" + drumsGS + " drumsGM2=" + drumsGM2 + " drumsXG=" + drumsXG
+										+ " drumsGM=" + drumsGM
+										+ "\n notes=" + notes + " channel=" + chan + " drumsExt10=" + drumsExt10
+										+ " drumsExtX=" + drumsExtX
+										+ "\n notes10=" + notes10 + " notesX=" + notesX
+										+ " isGSDrumChannel=" + (isRolandDrum(port, chan))
+										+ " isXGdrum="
+										+ (yamahaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+												&& yamahaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue())
+										+ " isGM2drum=" + (mmaDrumSwitches.get(port).get(chan).floorEntry(tick) != null
+												&& mmaDrumSwitches.get(port).get(chan).floorEntry(tick).getValue());
+					} else if (noteTrack != null && chan == DRUM_CHANNEL) {
+						// Chromatic note on ch10. Split it into new track.
+						noteTrack.add(evt);
+						moved = true;
+					}
+				}
 
-                if (!moved) {
-                    mainTrack.add(evt);
-                }
-            }
-        }
+				if (!moved) {
+					mainTrack.add(evt);
+				}
+			}
+		}
 
-        if (modified) {
-            return newSeq;
-        }
-        return song;
+		if (modified) {
+			return newSeq;
+		}
+		return song;
 	}
 
 	private Track createBrandDrumTrack(int drumsGS, int drumsXG, int drumsGM2, Sequence song) {
@@ -1473,7 +1557,8 @@ public class SequenceInfo implements MidiConstants {
 	 */
 	private boolean isDrumGM2(MidiEvent evt, int port, int chan) {
 		port = usingNewMidiLayout == 0 ? 0 : port;
-		if (MidiStandard.GM2 != standard || !mmaDrumSwitches.containsKey(port)) return false;
+		if (MidiStandard.GM2 != standard || !mmaDrumSwitches.containsKey(port))
+			return false;
 		TreeMap<Long, Boolean> mTree = mmaDrumSwitches.get(port).get(chan);
 		return mTree.floorEntry(evt.getTick()) != null && mTree.floorEntry(evt.getTick()).getValue();
 	}
@@ -1483,7 +1568,8 @@ public class SequenceInfo implements MidiConstants {
 	 */
 	private boolean isDrumXG(MidiEvent evt, int port, int chan) {
 		port = usingNewMidiLayout == 0 ? 0 : port;
-		if (MidiStandard.XG != standard || !yamahaDrumSwitches.containsKey(port)) return false;
+		if (MidiStandard.XG != standard || !yamahaDrumSwitches.containsKey(port))
+			return false;
 		TreeMap<Long, Boolean> yTree = yamahaDrumSwitches.get(port).get(chan);
 		return yTree.floorEntry(evt.getTick()) != null && yTree.floorEntry(evt.getTick()).getValue();
 	}
@@ -1493,20 +1579,23 @@ public class SequenceInfo implements MidiConstants {
 	 */
 	private boolean isDrumGS(int port, int chan) {
 		port = usingNewMidiLayout == 0 ? 0 : port;
-		return MidiStandard.GS == standard && isRolandDrum(port,chan);
+		return MidiStandard.GS == standard && isRolandDrum(port, chan);
 	}
 
 	/**
-	 * This method will move meta/sysex messages to the last note ON/OFF message tick.
+	 * This method will move meta/sysex messages to the last note ON/OFF message
+	 * tick.
 	 * It will also add any missing End Of Track messages.
-	 * Also it will truncate the song at start of silence if silence is more than a quarter of the song.
+	 * Also it will truncate the song at start of silence if silence is more than a
+	 * quarter of the song.
 	 *
 	 */
 	public long fixupTrackLength2(Sequence song) {
 		log.fine("Before: " + Util.formatDurationM(song.getMicrosecondLength()));
 		SequencerWrapper.TempoCacheSlow tempoCache = new SequencerWrapper.TempoCacheSlow(song);
 
-		long maxEmpty = Math.max(song.getTickLength()/4L, MidiUtils.microsecond2tick(song, 20L*AbcConstants.ONE_SECOND_MICROS, tempoCache));
+		long maxEmpty = Math.max(song.getTickLength() / 4L,
+				MidiUtils.microsecond2tick(song, 20L * AbcConstants.ONE_SECOND_MICROS, tempoCache));
 		Map<Integer, Map<Integer, Set<Integer>>> notesOn = new HashMap<>();
 		for (int port : portMap.values()) {
 			notesOn.putIfAbsent(port, new HashMap<>());
@@ -1515,7 +1604,7 @@ public class SequenceInfo implements MidiConstants {
 			}
 		}
 
-		record PortEvent (int port, MidiEvent evt, int trackIdx) {
+		record PortEvent(int port, MidiEvent evt, int trackIdx) {
 		}
 
 		List<PortEvent> allEvents = new ArrayList<>();
@@ -1542,7 +1631,8 @@ public class SequenceInfo implements MidiConstants {
 			MidiEvent evt = pe.evt;
 			long tick = evt.getTick();
 			int port = pe.port;
-			if (trackDead[pe.trackIdx] < tick) continue;
+			if (trackDead[pe.trackIdx] < tick)
+				continue;
 			if (MidiUtils.isMetaEndOfTrack(evt.getMessage())) {
 				trackDead[pe.trackIdx] = tick;
 				if (trackActiveNotes[pe.trackIdx] > 0) {
@@ -1563,10 +1653,11 @@ public class SequenceInfo implements MidiConstants {
 							break;
 						}
 					}
-					if (!silence) break;
+					if (!silence)
+						break;
 				}
 				if (silence) {
-					log.warning(fileName+": Quarter song is empty, will delete all after the empty starts.");
+					log.warning(fileName + ": Quarter song is empty, will delete all after the empty starts.");
 				} else {
 					earlyEndTick = tick;
 				}
@@ -1581,11 +1672,13 @@ public class SequenceInfo implements MidiConstants {
 				int ch = shortMessage.getChannel();
 				int pitch = shortMessage.getData1();
 
-				if (command == ShortMessage.NOTE_OFF || (command == ShortMessage.NOTE_ON && shortMessage.getData2() == 0)) {
+				if (command == ShortMessage.NOTE_OFF
+						|| (command == ShortMessage.NOTE_ON && shortMessage.getData2() == 0)) {
 					// Note OFF or Note ON with zero velocity
 					boolean wasOn = notesOn.get(port).get(ch).remove(pitch);
 					if (wasOn) {
-						if (trackActiveNotes[pe.trackIdx] > 0) trackActiveNotes[pe.trackIdx]--;
+						if (trackActiveNotes[pe.trackIdx] > 0)
+							trackActiveNotes[pe.trackIdx]--;
 						totalActiveNotes--;
 						// By doing Math.max here, we perfectly capture the latest valid Note Off!
 						endTick = Math.max(endTick, tick);
@@ -1599,7 +1692,7 @@ public class SequenceInfo implements MidiConstants {
 				}
 			}
 		}
-		log.fine("endTick = "+endTick+" earlyEndTick="+earlyEndTick);
+		log.fine("endTick = " + endTick + " earlyEndTick=" + earlyEndTick);
 		long absoluteEnd = Math.min(earlyEndTick, endTick);
 
 		for (int i = 0; i < tracks.length; i++) {
@@ -1644,8 +1737,8 @@ public class SequenceInfo implements MidiConstants {
 			track.add(MidiFactory.createEndOfTrackEvent(trackCutoff + 1));
 		}
 
-		//System.out.println("Real song duration: "
-		//		+ Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
+		// System.out.println("Real song duration: "
+		// + Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
 		log.fine("After: " + Util.formatDurationM(song.getMicrosecondLength()));
 		return absoluteEnd + 1L;
 	}
@@ -1673,12 +1766,13 @@ public class SequenceInfo implements MidiConstants {
 		allEvents.sort(Comparator.comparingLong(MidiEvent::getTick));
 
 		long earlyEndTick = 0L;
-		long maxEmpty = Math.max(song.getTickLength()/4L, MidiUtils.microsecond2tick(song, 20L*AbcConstants.ONE_SECOND_MICROS, tempoCache));
-		Map<Integer,Set<Integer>> notesOn = new HashMap<>();
+		long maxEmpty = Math.max(song.getTickLength() / 4L,
+				MidiUtils.microsecond2tick(song, 20L * AbcConstants.ONE_SECOND_MICROS, tempoCache));
+		Map<Integer, Set<Integer>> notesOn = new HashMap<>();
 		for (int ch = 0; ch < CHANNEL_COUNT_ABC; ch++) {
 			notesOn.put(ch, new HashSet<>());
 		}
-		for(MidiEvent evt : allEvents) {
+		for (MidiEvent evt : allEvents) {
 
 			if (evt.getTick() > earlyEndTick && evt.getTick() < earlyEndTick + maxEmpty) {
 				earlyEndTick = evt.getTick();
@@ -1699,7 +1793,8 @@ public class SequenceInfo implements MidiConstants {
 			if (evt.getMessage() instanceof ShortMessage shortMessage) {
 				int command = shortMessage.getCommand();
 				int pitch = shortMessage.getData1();
-				if (command == ShortMessage.NOTE_OFF || (command == ShortMessage.NOTE_ON && shortMessage.getData2() == 0)) {
+				if (command == ShortMessage.NOTE_OFF
+						|| (command == ShortMessage.NOTE_ON && shortMessage.getData2() == 0)) {
 					// note OFF or note ON with zero velocity
 					notesOn.get(shortMessage.getChannel()).remove(pitch);
 				} else if (command == ShortMessage.NOTE_ON) {
@@ -1728,18 +1823,19 @@ public class SequenceInfo implements MidiConstants {
 						suspectEvents[i].addFirst(evt);
 					} else {
 						if (evt.getMessage() instanceof ShortMessage) {
-							int command = ((ShortMessage)evt.getMessage()).getCommand();
-							if (command == ShortMessage.NOTE_OFF || (command == ShortMessage.NOTE_ON && ((ShortMessage)evt.getMessage()).getData2() == 0)) {
+							int command = ((ShortMessage) evt.getMessage()).getCommand();
+							if (command == ShortMessage.NOTE_OFF || (command == ShortMessage.NOTE_ON
+									&& ((ShortMessage) evt.getMessage()).getData2() == 0)) {
 								// note OFF or note ON with zero velocity
 								endTick = evt.getTick();
-								log.finer(i+": last note OFF = "+MidiUtils.midiEventToShortString(evt));
+								log.finer(i + ": last note OFF = " + MidiUtils.midiEventToShortString(evt));
 								break;
 							}
 							if (command == ShortMessage.NOTE_ON && lastEOT != null) {
 								// last note is missing note off, so it should end at EOT
 								// if no EOT after it, we ignore it.
 								endTick = lastEOT.getTick();
-								log.finer(i+": endTick = lastEOT = "+endTick);
+								log.finer(i + ": endTick = lastEOT = " + endTick);
 								break;
 							}
 						}
@@ -1747,10 +1843,11 @@ public class SequenceInfo implements MidiConstants {
 				}
 			}
 		}
-		log.fine("endTick = "+endTick+" earlyEndTick="+earlyEndTick);
+		log.fine("endTick = " + endTick + " earlyEndTick=" + earlyEndTick);
 
 		/*
-		 * Weakness in this, is that if there is note OFF far at end without corresponding note ON,
+		 * Weakness in this, is that if there is note OFF far at end without
+		 * corresponding note ON,
 		 * then notegraphs will show empty until that useless note OFF.
 		 * TrackInfo will try to fix that.
 		 */
@@ -1764,7 +1861,8 @@ public class SequenceInfo implements MidiConstants {
 						track.remove(evt);
 
 						log.finer("Moving event from "
-								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, evt.getTick(), tempoCache)) + " to "
+								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, evt.getTick(), tempoCache))
+								+ " to "
 								+ Util.formatDurationM(MidiUtils.tick2microsecond(song, endTick, tempoCache)));
 
 						// Why do we do this, events after endTick don't affect song,
@@ -1784,7 +1882,8 @@ public class SequenceInfo implements MidiConstants {
 			boolean okay = false;
 			for (int e = track.size() - 1; e >= 0; e--) {
 				MidiEvent evt = track.get(e);
-				if (MidiUtils.isMetaEndOfTrack(evt.getMessage()) && evt.getTick() <= Math.min(earlyEndTick, endTick) + 1) {
+				if (MidiUtils.isMetaEndOfTrack(evt.getMessage())
+						&& evt.getTick() <= Math.min(earlyEndTick, endTick) + 1) {
 					okay = true;
 					break;
 				}
@@ -1802,7 +1901,7 @@ public class SequenceInfo implements MidiConstants {
 		// remove all events after earlyEndTick
 		// isn't this a risk to remove tracknames etc.?
 		for (Track track : tracks) {
-			for (int j = track.size()-1; j >= 0; j--) {
+			for (int j = track.size() - 1; j >= 0; j--) {
 				MidiEvent evt = track.get(j);
 				if (evt.getTick() > earlyEndTick + 1L) {
 					track.remove(evt);
@@ -1811,24 +1910,26 @@ public class SequenceInfo implements MidiConstants {
 				}
 			}
 		}
-		//System.out.println("last="+last+" endTick="+endTick);
+		// System.out.println("last="+last+" endTick="+endTick);
 
-		//System.out.println("Real song duration: "
-		//		+ Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
+		// System.out.println("Real song duration: "
+		// + Util.formatDurationM(MidiUtils.tick2microsecond(song, last, tempoCache)));
 		log.fine("After: " + Util.formatDurationM(song.getMicrosecondLength()));
 		return earlyEndTick + 1L;
 	}
 
 	/**
 	 * 
-	 * @return the result from splitting tracks with multiple instruments into 1 track per instrument.
+	 * @return the result from splitting tracks with multiple instruments into 1
+	 *         track per instrument.
 	 */
 	public Sequence split() throws InvalidMidiDataException, FileParseException, IOException {
 		TrackSplitter splitter = new TrackSplitter();
 		Sequence sequence2 = null;
-		if (midiFile == null) return null;
+		if (midiFile == null)
+			return null;
 		sequence2 = splitter.split(midiFile, onlyFirstTrackTempos);
-		
+
 		return sequence2;
 	}
 


### PR DESCRIPTION
This pull request refactors the `MidiText` class, focusing on code cleanup, improved formatting, and the removal of unused or unnecessary code. The changes do not alter the core logic but make the codebase more maintainable and readable.

Code cleanup and simplification:

* Removed the unused `decodeKarakan` method and associated regular expression and imports from `MidiText.java`. [[1]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L13-L14) [[2]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L28-L29) [[3]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L321-L344)
* Removed the `cache` field and its usage, as well as related commented-out code, since it is no longer needed. [[1]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L28-L29) [[2]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L39-R42) [[3]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L473-R465)

Formatting and readability improvements:

* Reformatted code for better readability, including expanding multi-statement lines, improving comment formatting, and splitting long lines. [[1]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L39-R42) [[2]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L65-R71) [[3]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L101-R97) [[4]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L133-R130) [[5]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L175-R173) [[6]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L235-R234) [[7]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L259-R259) [[8]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L288-R289) [[9]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L305-R307) [[10]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L582-R597) [[11]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L631-R641) [[12]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L660-R676) [[13]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L683-R692) [[14]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L703-R713) [[15]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L736-R752) [[16]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L783-R796) [[17]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L810-R828) [[18]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674R838)
* Improved JavaDoc and inline comments to clarify code behavior and intent. [[1]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L397-R399) [[2]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L420-R415) [[3]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674L810-R828) [[4]](diffhunk://#diff-63cdbefdf70bffe6df3f7de34717e9f216e98d8a4368c77f3f693958f4747674R838)

These changes make the code easier to understand and maintain without affecting its external behavior.

> [!IMPORTANT]
> This PR removes code that appeared to be unused. I verified that it isn't referenced in the current codebase, but if any of it was kept intentionally for future work, please review this part carefully.