### PR TITLE
Enhance temporary file creation and improve error logging

### DIFF
--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2614,11 +2614,11 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		
 		abcSong.setProjectFile(tmpMsx);
 		abcSong.setSourceFile(newSource);
-		
+
 		if (!finishSave(false)) {
-			// failed to save tmp - restore
 			abcSong.setProjectFile(originalMsx);
 			abcSong.setSourceFile(oldSource);
+			log.log(Level.SEVERE, "Failed to save temporary MSX file");
 			return false;
 		}
 

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2608,6 +2608,7 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
         		Util.MSX_FILE_EXTENSION)
     		.toFile();
 		} catch (IOException e) {
+			log.log(Level.SEVERE, "Failed to create temporary MSX file for saving project state", e);
 			return false;
 		}
 		

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
@@ -2595,7 +2596,17 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		boolean modified = abcSongModified;
 		File tmpMsx;
 		try {
-			tmpMsx = File.createTempFile("tmpproj", Util.MSX_FILE_EXTENSION);
+			/* Create a temporary MSX file to save the current project state with the new
+			* source file. {@link Files#createTempFile(Path, String, String)} creates the
+			* file with restrictive default permissions (typically {@code -rw-------} on
+			* POSIX systems), making it accessible only to the creating user. This helps
+			* prevent local information disclosure vulnerabilities.
+			*/
+			tmpMsx = Files.createTempFile(
+        		Path.of(System.getProperty("java.io.tmpdir")),
+        		"tmpproj",
+        		Util.MSX_FILE_EXTENSION)
+    		.toFile();
 		} catch (IOException e) {
 			return false;
 		}

--- a/src/com/digero/maestro/view/ProjectFrame.java
+++ b/src/com/digero/maestro/view/ProjectFrame.java
@@ -2594,11 +2594,11 @@ public class ProjectFrame extends JFrame implements TableLayoutConstants, ICompi
 		File originalMsx = abcSong.getProjectFile();
 		File oldSource = abcSong.getSourceFile();
 		boolean modified = abcSongModified;
-		File tmpMsx;
+		final File tmpMsx;
 		try {
 			/* Create a temporary MSX file to save the current project state with the new
-			* source file. {@link Files#createTempFile(Path, String, String)} creates the
-			* file with restrictive default permissions (typically {@code -rw-------} on
+			* source file. Files.createTempFile() creates the
+			* file with restrictive default permissions (typically -rw------- on
 			* POSIX systems), making it accessible only to the creating user. This helps
 			* prevent local information disclosure vulnerabilities.
 			*/


### PR DESCRIPTION

This pull request updates the way temporary files are created in the `ProjectFrame` class. The most important changes are:

**Improvements:**

* Updated temporary file creation in `reloadWithNewSource` to use `Files.createTempFile`, which creates files with restrictive permissions (typically only accessible by the creating user), reducing the risk of local information disclosure vulnerabilities.
* Added an import for `java.nio.file.Files` to support the new method of temporary file creation.

**Error handling:**

* Added logging for failures when creating or saving the temporary MSX file, providing more detailed error information for debugging.