### PR TITLE
Refactor i18n handling and improve localization management

### DIFF
--- a/src/com/digero/common/i18n/I18n.java
+++ b/src/com/digero/common/i18n/I18n.java
@@ -1,0 +1,74 @@
+package com.digero.common.i18n;
+
+import java.text.MessageFormat;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jetbrains.annotations.PropertyKey;
+
+/**
+ * Utility class for handling UI text localization and retrieval.
+ * Initialize I18n after LocaleManager has been initialized to ensure the
+ * correct locale is used.
+ */
+public final class I18n {
+    private static final Logger LOGGER = Logger.getLogger(I18n.class.getName());
+    private static final String BUNDLE_NAME = "uitext";
+    private static volatile ResourceBundle RESOURCE_BUNDLE; // if the locale is changed at runtime, reload the resource
+                                                            // bundle accordingly
+    private static volatile boolean initialized;
+
+    private I18n() {
+        // Prevent instantiation
+    }
+
+    public static synchronized void init() {
+        if (initialized) {
+            return;
+        }
+        reload();
+        initialized = true;
+    }
+
+    public static String get(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... args) {
+        if (RESOURCE_BUNDLE == null) {
+            throw new IllegalStateException("I18n has not been initialized");
+        }
+        try {
+            String localizedString = RESOURCE_BUNDLE.getString(key);
+
+            // If no arguments are provided, return the string directly
+            if (args.length == 0) {
+                return localizedString;
+            }
+
+            // If arguments are provided, format the string using MessageFormat
+            MessageFormat messageFormat = new MessageFormat(
+                    localizedString,
+                    LocaleManager.getLocale());
+
+            return messageFormat.format(args);
+
+        } catch (MissingResourceException | IllegalArgumentException e) {
+            LOGGER.log(Level.SEVERE, "Failed to resolve localized string for key: \"" + key + "\"", e);
+        }
+        return "!" + key + "!";
+    }
+
+    /**
+     * Reloads the resource bundle to reflect any changes in the locale.
+     * This should be called after changing the locale at runtime.
+     */
+    public static synchronized void reload() {
+        try {
+            RESOURCE_BUNDLE = ResourceBundle.getBundle(
+                    BUNDLE_NAME,
+                    LocaleManager.getLocale());
+        } catch (MissingResourceException e) {
+            LOGGER.log(Level.SEVERE, "Failed to reload resource bundle for locale: " + LocaleManager.getLocale(), e);
+        }
+    }
+
+}

--- a/src/com/digero/common/i18n/I18n.java
+++ b/src/com/digero/common/i18n/I18n.java
@@ -18,7 +18,7 @@ public final class I18n {
     private static final String BUNDLE_NAME = "uitext";
     private static volatile ResourceBundle RESOURCE_BUNDLE; // if the locale is changed at runtime, reload the resource
                                                             // bundle accordingly
-    private static volatile boolean initialized;
+    private static boolean initialized = false;
 
     private I18n() {
         // Prevent instantiation
@@ -28,12 +28,15 @@ public final class I18n {
         if (initialized) {
             return;
         }
+        if (RESOURCE_BUNDLE == null) {
+            throw new IllegalStateException("Unable to initialize I18n");
+        }
         reload();
         initialized = true;
     }
 
     public static String get(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... args) {
-        if (RESOURCE_BUNDLE == null) {
+        if (!initialized) {
             throw new IllegalStateException("I18n has not been initialized");
         }
         try {
@@ -63,9 +66,12 @@ public final class I18n {
      */
     public static synchronized void reload() {
         try {
-            RESOURCE_BUNDLE = ResourceBundle.getBundle(
+            ResourceBundle bundle = ResourceBundle.getBundle(
                     BUNDLE_NAME,
                     LocaleManager.getLocale());
+
+            RESOURCE_BUNDLE = bundle;
+
         } catch (MissingResourceException e) {
             LOGGER.log(Level.SEVERE, "Failed to reload resource bundle for locale: " + LocaleManager.getLocale(), e);
         }

--- a/src/com/digero/common/i18n/LocaleManager.java
+++ b/src/com/digero/common/i18n/LocaleManager.java
@@ -13,9 +13,9 @@ import javax.swing.SwingUtilities;
 import com.digero.maestro.MaestroMain;
 
 /**
- * Handles UI text localization and retrieval.
+ * Manages the application's current locale and locale preferences.
  *
- * Initialize LocaleManager before creating Swing UI components.
+ * Initialize before creating Swing UI components.
  * LocaleManager.init() may show a language selection dialog on first run,
  * so it should be called from the application startup sequence.
  */
@@ -33,7 +33,7 @@ public final class LocaleManager {
             Locale.GERMAN);
 
     private static volatile Locale locale = Locale.ENGLISH;
-    private static volatile boolean initialized;
+    private static boolean initialized = false;
 
     private static final String LANGUAGE_SELECTION_MESSAGE = "Language/Langue/Sprache";
     private static final String LANGUAGE_SELECTION_TITLE = "Maestro Language";
@@ -54,8 +54,18 @@ public final class LocaleManager {
 
         String lang = PREFS.get("locale", null);
 
+        // Migrate legacy locale setting "US" to Locale.ENGLISH
+        final String LEGACY_LOCALE_US = "US";
+        if (LEGACY_LOCALE_US.equalsIgnoreCase(lang)) {
+            LOGGER.log(Level.INFO, "Migrating legacy locale setting US to " + Locale.ENGLISH);
+            lang = Locale.ENGLISH.getLanguage();
+            PREFS.put("locale", lang);
+        }
+
+        final String selectedLanguage = lang;
+
         locale = SUPPORTED_LOCALES.stream()
-                .filter(l -> l.getLanguage().equals(lang))
+                .filter(l -> l.getLanguage().equals(selectedLanguage))
                 .findFirst()
                 .orElseGet(() -> {
                     Locale selected = promptUserForLocale();

--- a/src/com/digero/common/i18n/LocaleManager.java
+++ b/src/com/digero/common/i18n/LocaleManager.java
@@ -1,0 +1,161 @@
+package com.digero.common.i18n;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Locale;
+import java.util.prefs.Preferences;
+
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+import com.digero.maestro.MaestroMain;
+
+/**
+ * Handles UI text localization and retrieval.
+ *
+ * Initialize LocaleManager before creating Swing UI components.
+ * LocaleManager.init() may show a language selection dialog on first run,
+ * so it should be called from the application startup sequence.
+ */
+public final class LocaleManager {
+    private static final Logger LOGGER = Logger.getLogger(LocaleManager.class.getName());
+
+    // Keep preferences anchored to the application package so refactoring
+    // common.i18n does not move user settings.
+    private static final Preferences PREFS = Preferences.userNodeForPackage(MaestroMain.class)
+            .node("miscSettings");
+
+    private static final List<Locale> SUPPORTED_LOCALES = List.of(
+            Locale.ENGLISH,
+            Locale.FRENCH,
+            Locale.GERMAN);
+
+    private static volatile Locale locale = Locale.ENGLISH;
+    private static volatile boolean initialized;
+
+    private static final String LANGUAGE_SELECTION_MESSAGE = "Language/Langue/Sprache";
+    private static final String LANGUAGE_SELECTION_TITLE = "Maestro Language";
+
+    private LocaleManager() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Initializes the locale settings. If a locale is already stored in
+     * preferences, it will be used.
+     * Otherwise, the user will be prompted to select a locale.
+     */
+    public static synchronized void init() {
+        if (initialized) {
+            return;
+        }
+
+        String lang = PREFS.get("locale", null);
+
+        locale = SUPPORTED_LOCALES.stream()
+                .filter(l -> l.getLanguage().equals(lang))
+                .findFirst()
+                .orElseGet(() -> {
+                    Locale selected = promptUserForLocale();
+                    PREFS.put("locale", selected.getLanguage());
+                    return selected;
+                });
+
+        LOGGER.info("Using locale: " + locale);
+        initialized = true;
+    }
+
+    private static Locale promptUserForLocale() {
+        if (SwingUtilities.isEventDispatchThread()) {
+            return showLocaleDialog();
+        }
+
+        final Locale[] result = { Locale.ENGLISH };
+
+        try {
+            SwingUtilities.invokeAndWait(() -> result[0] = showLocaleDialog());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Interrupted while selecting locale", e);
+        } catch (InvocationTargetException e) {
+            LOGGER.log(Level.WARNING, "Failed to show locale dialog", e);
+        }
+
+        return result[0];
+    }
+
+    /**
+     * Prompts the user to select a locale from the supported locales.
+     * 
+     * @return The selected locale, or Locale.ENGLISH if the user cancels the
+     *         dialog.
+     */
+    private static Locale showLocaleDialog() {
+        Object[] languages = SUPPORTED_LOCALES.stream()
+                .map(locale -> locale.getDisplayLanguage(locale))
+                .toArray();
+
+        int selectedIndex = JOptionPane.showOptionDialog(
+                null,
+                LANGUAGE_SELECTION_MESSAGE,
+                LANGUAGE_SELECTION_TITLE,
+                JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                languages,
+                languages[0]);
+
+        if (selectedIndex >= 0 && selectedIndex < SUPPORTED_LOCALES.size()) {
+            return SUPPORTED_LOCALES.get(selectedIndex);
+        } else {
+            return Locale.ENGLISH;
+        }
+    }
+
+    /**
+     * Returns the currently selected locale.
+     * 
+     * @return The current locale.
+     */
+    public static Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * Sets the current locale to the specified newLocale. If the newLocale is not
+     * supported, it will not change the current locale.
+     * 
+     * @param newLocale The new locale to set.
+     */
+    public static void setLocale(Locale newLocale) {
+        if (newLocale == null) {
+            LOGGER.warning("Attempted to set null locale");
+            return;
+        }
+
+        Locale supportedLocale = SUPPORTED_LOCALES.stream()
+                .filter(l -> l.getLanguage().equals(newLocale.getLanguage()))
+                .findFirst()
+                .orElse(null);
+
+        if (supportedLocale == null) {
+            LOGGER.warning("Attempted to set unsupported locale: " + newLocale);
+            return;
+        }
+
+        locale = supportedLocale;
+        PREFS.put("locale", supportedLocale.getLanguage());
+        LOGGER.info("Locale changed to: " + supportedLocale);
+    }
+
+    /**
+     * Returns a list of supported locales.
+     * 
+     * @return A list of supported locales.
+     */
+    public static List<Locale> getSupportedLocales() {
+        return List.copyOf(SUPPORTED_LOCALES);
+    }
+}

--- a/src/com/digero/common/view/UIText.java
+++ b/src/com/digero/common/view/UIText.java
@@ -18,12 +18,17 @@ import java.util.prefs.Preferences;
 
 /**
  * Utility class for handling UI text localization and retrieval.
- * Do NOT access this in static fields in main classes. (AbcPlayer, MaestroMain, AbcTools)
+ * Do NOT access this in static fields in main classes. (AbcPlayer, MaestroMain,
+ * AbcTools)
  * And best wait AFTER the first use of Swing thread.
  * And after Logging has been init.
+ * 
+ * @deprecated Use {@link com.digero.common.i18n.I18n} and
+ *             {@link com.digero.common.i18n.LocaleManager} instead.
  */
+@Deprecated(forRemoval = true)
 public class UIText {
-    private static final Logger log = Logger.getLogger("locale"); //NON-NLS
+    private static final Logger log = Logger.getLogger("locale"); // NON-NLS
     private static String locale = null;
     private static final @NonNls String BUNDLE_NAME = "uitext";
     private static ResourceBundle uiText = null;
@@ -36,20 +41,26 @@ public class UIText {
     private static final @NonNls String mainKey = "locale";
 
     static {
-        //Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings").remove(mainKey);
-        locale = Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings").get(mainKey, null); //NON-NLS
-        log.info("Stored locale: " + (locale==null?"null":locale));
+        // Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings").remove(mainKey);
+        locale = Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings").get(mainKey, null); // NON-NLS
+        log.info("Stored locale: " + (locale == null ? "null" : locale));
 
         if (locale == null) {
-            int[] choice = {-1};
+            int[] choice = { -1 };
             if (!GraphicsEnvironment.isHeadless()) {// test if we are in code testing
                 log.info("No locale stored, prompting user");
                 try {
                     if (SwingUtilities.isEventDispatchThread()) {
-                        choice[0] = JOptionPane.showOptionDialog(null, "Language/Langue/Sprache", "Maestro Language", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, new Object[]{LANG_EN_NAME, LANG_FR_NAME, LANG_DE_NAME}, LANG_EN_NAME); //NON-NLS  //NON-NLS
+                        choice[0] = JOptionPane.showOptionDialog(null, "Language/Langue/Sprache", "Maestro Language",
+                                JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+                                new Object[] { LANG_EN_NAME, LANG_FR_NAME, LANG_DE_NAME }, LANG_EN_NAME); // NON-NLS
+                                                                                                          // //NON-NLS
                     } else {
                         SwingUtilities.invokeAndWait(() -> {
-                            choice[0] = JOptionPane.showOptionDialog(null, "Language/Langue/Sprache", "Maestro Language", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, new Object[]{LANG_EN_NAME, LANG_FR_NAME, LANG_DE_NAME}, LANG_EN_NAME); //NON-NLS  //NON-NLS
+                            choice[0] = JOptionPane.showOptionDialog(null, "Language/Langue/Sprache",
+                                    "Maestro Language", JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+                                    new Object[] { LANG_EN_NAME, LANG_FR_NAME, LANG_DE_NAME }, LANG_EN_NAME); // NON-NLS
+                                                                                                              // //NON-NLS
                         });
                     }
                 } catch (InterruptedException | InvocationTargetException e) {
@@ -57,13 +68,17 @@ public class UIText {
                 }
             }
 
-            if (choice[0] == 0) locale = LANG_EN;
-            else if (choice[0] == 1) locale = LANG_FR;
-            else if (choice[0] == 2) locale = LANG_DE;
-            else locale = LANG_EN;
+            if (choice[0] == 0)
+                locale = LANG_EN;
+            else if (choice[0] == 1)
+                locale = LANG_FR;
+            else if (choice[0] == 2)
+                locale = LANG_DE;
+            else
+                locale = LANG_EN;
 
             if (!GraphicsEnvironment.isHeadless()) {
-                log.fine("saving "+locale);
+                log.fine("saving " + locale);
                 Preferences.userNodeForPackage(MaestroMain.class).node("miscSettings").put(mainKey, locale);
             }
         }
@@ -73,10 +88,10 @@ public class UIText {
             // Backwards compat; Initially used "US" instead of "en".
             locale = LANG_EN;
         }
-        locale = locale.toLowerCase();//handle FR and DE
+        locale = locale.toLowerCase();// handle FR and DE
 
         if (LANG_EN.equals(locale)) {
-            //selectedLocale = Locale.ROOT; // Forces use of uitext.properties
+            // selectedLocale = Locale.ROOT; // Forces use of uitext.properties
             selectedLocale = Locale.of(locale);
         } else {
             selectedLocale = Locale.of(locale);
@@ -85,21 +100,21 @@ public class UIText {
         uiText = ResourceBundle.getBundle(BUNDLE_NAME, selectedLocale);
     }
 
-    public static @NotNull String get(@PropertyKey(resourceBundle = BUNDLE_NAME)String key, Locale local) {
+    public static @NotNull String get(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Locale local) {
         try {
             return ResourceBundle.getBundle(BUNDLE_NAME, local).getString(key);
         } catch (Exception e) {
-            log.warning("Failed to load UI text for key \"" + key + "\", locale is " + local); //NON-NLS //NON-NLS
+            log.warning("Failed to load UI text for key \"" + key + "\", locale is " + local); // NON-NLS //NON-NLS
             return "!" + key + "!";
         }
     }
 
-    public static @NotNull String get(@PropertyKey(resourceBundle = BUNDLE_NAME)String key, Object... args) {
+    public static @NotNull String get(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... args) {
         String value;
         try {
             value = uiText.getString(key);
         } catch (MissingResourceException e) {
-            log.warning("Failed to load UI text for key \"" + key + "\", locale is " + locale); //NON-NLS //NON-NLS
+            log.warning("Failed to load UI text for key \"" + key + "\", locale is " + locale); // NON-NLS //NON-NLS
             return "!" + key + "!";
         }
 


### PR DESCRIPTION
## Scope

This pull request introduces a new internationalization (i18n) framework for UI text localization and locale management. It separates concerns by providing `I18n` for localized string retrieval and formatting, and `LocaleManager` for locale selection, persistence, and user prompting. The existing `UIText` class is deprecated, with documentation updated to guide toward the new API.

**New i18n framework**

- Added `I18n` for retrieving and formatting localized UI strings, with support for runtime locale changes and resource bundle reloading.
- Added `LocaleManager` for locale initialization, user selection, supported locales, and persistence using Java Preferences.

**Deprecation**

- Deprecated the existing `UIText` class and updated its documentation to direct to `I18n` and `LocaleManager`.

## Task List

- [x] Introduce `LocaleManager`
- [x] Introduce `I18n`
- [x] Simplify locale initialization
- [x] Support runtime resource bundle reloading
- [ ] Initialize `LocaleManager` in `AbcPlayer` and `Maestro`
- [ ] Initialize `I18n` in `AbcPlayer` and `Maestro`
- [ ] Replace `UIText.get()` usages with `I18n.get()`
- [ ] Perform a clean build and run `AbcPlayer` and `Maestro`
- [ ] Remove the legacy `UIText` class

> [!Note]
> This PR is currently a draft. I plan to complete the remaining migration work after the overall design has been reviewed.