### PR TITLE
introduce new type-safe settings library 

### DIFF
--- a/src/com/digero/common/settings/MaestroSettingsExample.java
+++ b/src/com/digero/common/settings/MaestroSettingsExample.java
@@ -1,0 +1,153 @@
+package com.digero.common.settings;
+
+import java.util.Locale;
+
+import com.digero.common.settings.converter.DefaultConverters;
+import com.digero.common.settings.store.InMemorySettingsStore;
+
+/**
+ * Example implementation of a settings manager using the
+ * MaestroSettingsExampleImplementation class.
+ * This class demonstrates how to define and manage application settings using
+ * the provided Settings API.
+ */
+public class MaestroSettingsExample {
+
+    // The underlying Settings instance used for managing settings
+    private final Settings settings;
+
+    // Singleton instance of MaestroSettingsExampleImplementation
+    private static volatile MaestroSettingsExample instance;
+
+    // Define setting keys with default values and converters
+    private static final SettingKey<Integer> FONT_SIZE = SettingKey.of("fontSize", 12, DefaultConverters.INTEGER);
+    private static final SettingKey<Boolean> DARK_MODE = SettingKey.of("darkMode", false, DefaultConverters.BOOLEAN);
+    private static final SettingKey<String> USERNAME = SettingKey.of("username", "", DefaultConverters.STRING);
+    private static final SettingKey<Locale> LOCALE = SettingKey.of("locale", Locale.ENGLISH, DefaultConverters.LOCALE);
+
+    /**
+     * Initializes the singleton instance of MaestroSettingsExampleImplementation
+     * with the provided SettingsStore.
+     * This method must be called before calling get().
+     *
+     * @param store The SettingsStore to use for storing settings.
+     * @return The initialized instance of MaestroSettingsExampleImplementation or
+     *         the existing instance if it has already been initialized.
+     */
+    public static MaestroSettingsExample init(SettingsStore store) {
+        if (instance == null) {
+            synchronized (MaestroSettingsExample.class) {
+                if (instance == null) {
+                    instance = new MaestroSettingsExample(store);
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Returns the singleton instance of MaestroSettingsExampleImplementation.
+     * This method should only be called after init() has been called.
+     *
+     * @return The singleton instance of MaestroSettingsExampleImplementation.
+     * @throws IllegalStateException if init() has not been called before this
+     *                               method.
+     */
+    public static MaestroSettingsExample get() {
+        if (instance == null) {
+            throw new IllegalStateException("MaestroSettingsExampleImplementation not initialized");
+        }
+        return instance;
+    }
+
+    /**
+     * Private constructor to enforce singleton pattern.
+     *
+     * @param store The SettingsStore to use for storing settings.
+     */
+    private MaestroSettingsExample(SettingsStore store) {
+        this.settings = new Settings(store);
+    }
+
+    public int getFontSize() {
+        return settings.get(FONT_SIZE);
+    }
+
+    public void setFontSize(int size) {
+        settings.set(FONT_SIZE, size);
+    }
+
+    public boolean isDarkMode() {
+        return settings.get(DARK_MODE);
+    }
+
+    public void setDarkMode(boolean enabled) {
+        settings.set(DARK_MODE, enabled);
+    }
+
+    public String getUsername() {
+        return settings.get(USERNAME);
+    }
+
+    public void setUsername(String username) {
+        settings.set(USERNAME, username);
+    }
+
+    public Locale getLocale() {
+        return settings.get(LOCALE);
+    }
+
+    public void setLocale(Locale locale) {
+        settings.set(LOCALE, locale);
+    }
+
+    public void remove(SettingKey<?> key) {
+        settings.remove(key);
+    }
+
+    public void clear() {
+        settings.clear();
+    }
+
+    public void flush() {
+        settings.flush();
+    }
+
+    /**
+     * Example usage of the MaestroSettingsExampleImplementation class.
+     * This inner class demonstrates how to initialize and use the settings
+     * manager.
+     */
+    private static class UsageExample {
+        public void exampleUsage() {
+            // Initialize the settings manager with a SettingsStore implementation
+            SettingsStore store = new InMemorySettingsStore(); // Replace with actual implementation
+            MaestroSettingsExample.init(store);
+
+            // Access the singleton instance
+            MaestroSettingsExample settingsManager = MaestroSettingsExample.get();
+
+            // Set and get settings
+            settingsManager.setFontSize(14);
+            int fontSize = settingsManager.getFontSize();
+
+            settingsManager.setDarkMode(true);
+            boolean darkModeEnabled = settingsManager.isDarkMode();
+
+            settingsManager.setUsername("JohnDoe");
+            String username = settingsManager.getUsername();
+
+            settingsManager.setLocale(Locale.FRENCH);
+            Locale locale = settingsManager.getLocale();
+
+            // Remove a setting
+            settingsManager.remove(FONT_SIZE);
+
+            // Clear all settings
+            settingsManager.clear();
+
+            // Flush changes to the underlying store
+            settingsManager.flush();
+        }
+    }
+}

--- a/src/com/digero/common/settings/MaestroSettingsExample.java
+++ b/src/com/digero/common/settings/MaestroSettingsExample.java
@@ -118,6 +118,7 @@ public class MaestroSettingsExample {
      * This inner class demonstrates how to initialize and use the settings
      * manager.
      */
+    @SuppressWarnings("unused")
     private static class UsageExample {
         public void exampleUsage() {
             // Initialize the settings manager with a SettingsStore implementation

--- a/src/com/digero/common/settings/SettingConverter.java
+++ b/src/com/digero/common/settings/SettingConverter.java
@@ -1,0 +1,26 @@
+package com.digero.common.settings;
+
+/**
+ * A converter interface for serializing and deserializing setting values.
+ *
+ * @param <T> the type of the setting value
+ */
+public interface SettingConverter<T> {
+
+    /**
+     * Serializes the given value to a string representation.
+     *
+     * @param value the value to serialize
+     * @return the string representation of the value
+     */
+    String serialize(T value);
+
+    /**
+     * Deserializes the given string representation to a value of type T.
+     *
+     * @param value the string representation of the value
+     * @return the deserialized value
+     */
+    T deserialize(String value);
+
+}

--- a/src/com/digero/common/settings/SettingKey.java
+++ b/src/com/digero/common/settings/SettingKey.java
@@ -13,11 +13,14 @@ public final class SettingKey<T> {
     private final boolean hasDefaultValue;
 
     /**
-     * Private constructor to enforce the use of factory methods.
-     * 
-     * @param key          the key for the setting
-     * @param converter    the converter for the setting
-     * @param defaultValue the default value for the setting
+     * Constructs a new SettingKey with the specified key, default value, and
+     * converter.
+     *
+     * @param key             the key for the setting
+     * @param defaultValue    the default value for the setting
+     * @param converter       the converter for the setting
+     * @param hasDefaultValue whether this SettingKey has a default value
+     * @exception NullPointerException if key or converter is null
      */
     private SettingKey(String key, T defaultValue, SettingConverter<T> converter, boolean hasDefaultValue) {
         this.key = Objects.requireNonNull(key, "key must not be null");
@@ -32,17 +35,8 @@ public final class SettingKey<T> {
      * @param key       the key for the setting
      * @param converter the converter for the setting
      * @return a new SettingKey without a default value
-     * @exception NullPointerException if {@code key} or {@code converter} is null
-     * @apiNote This method is a convenience method for creating a
-     *          {@link SettingKey}
-     *          without a default value.<br>
-     *          If you want to create a SettingKey with a
-     *          default value, use the {@link #of(String, Object, SettingConverter)}
-     *          method instead.
      */
     public static <T> SettingKey<T> of(String key, SettingConverter<T> converter) {
-        Objects.requireNonNull(key, "key must not be null");
-        Objects.requireNonNull(converter, "converter must not be null");
         return new SettingKey<>(key, null, converter, false);
     }
 
@@ -54,16 +48,8 @@ public final class SettingKey<T> {
      * @param defaultValue the default value for the setting
      * @param <T>          the type of the setting value
      * @return a new SettingKey with the specified default value
-     * @exception NullPointerException if {@code key} or {@code converter} is null
-     * @apiNote This method is a convenience method for creating a
-     *          {@link SettingKey}
-     *          with a default value.<br>
-     *          If you want to create a SettingKey without a default value, use the
-     *          {@link #of(String, SettingConverter)} method instead.
      */
     public static <T> SettingKey<T> of(String key, T defaultValue, SettingConverter<T> converter) {
-        Objects.requireNonNull(key, "key must not be null");
-        Objects.requireNonNull(converter, "converter must not be null");
         return new SettingKey<>(key, defaultValue, converter, true);
     }
 

--- a/src/com/digero/common/settings/SettingKey.java
+++ b/src/com/digero/common/settings/SettingKey.java
@@ -13,18 +13,24 @@ public final class SettingKey<T> {
     private final boolean hasDefaultValue;
 
     /**
-     * Constructs a new SettingKey with the specified key, default value, and
-     * converter.
+     * Constructs a new SettingKey with the specified key, default value, converter,
+     * and a flag indicating whether it has a default value.
      *
      * @param key             the key for the setting
      * @param defaultValue    the default value for the setting
      * @param converter       the converter for the setting
-     * @param hasDefaultValue whether this SettingKey has a default value
-     * @exception NullPointerException if key or converter is null
+     * @param hasDefaultValue true if this SettingKey has a default value, false
+     *                        otherwise
      */
     private SettingKey(String key, T defaultValue, SettingConverter<T> converter, boolean hasDefaultValue) {
         this.key = Objects.requireNonNull(key, "key must not be null");
         this.converter = Objects.requireNonNull(converter, "converter must not be null");
+
+        // If hasDefaultValue is true, ensure that defaultValue is not null
+        if (hasDefaultValue) {
+            Objects.requireNonNull(defaultValue, "defaultValue must not be null");
+        }
+
         this.defaultValue = defaultValue;
         this.hasDefaultValue = hasDefaultValue;
     }

--- a/src/com/digero/common/settings/SettingKey.java
+++ b/src/com/digero/common/settings/SettingKey.java
@@ -1,0 +1,117 @@
+package com.digero.common.settings;
+
+import java.util.Objects;
+
+/**
+ * A class representing a key for a setting, including its default
+ * value and its converter.
+ */
+public final class SettingKey<T> {
+    private final String key;
+    private final T defaultValue;
+    private final SettingConverter<T> converter;
+    private final boolean hasDefaultValue;
+
+    /**
+     * Private constructor to enforce the use of factory methods.
+     * 
+     * @param key          the key for the setting
+     * @param converter    the converter for the setting
+     * @param defaultValue the default value for the setting
+     */
+    private SettingKey(String key, T defaultValue, SettingConverter<T> converter, boolean hasDefaultValue) {
+        this.key = Objects.requireNonNull(key, "key must not be null");
+        this.converter = Objects.requireNonNull(converter, "converter must not be null");
+        this.defaultValue = defaultValue;
+        this.hasDefaultValue = hasDefaultValue;
+    }
+
+    /**
+     * Creates a new SettingKey without a default value.
+     *
+     * @param key       the key for the setting
+     * @param converter the converter for the setting
+     * @return a new SettingKey without a default value
+     * @exception NullPointerException if {@code key} or {@code converter} is null
+     * @apiNote This method is a convenience method for creating a
+     *          {@link SettingKey}
+     *          without a default value.<br>
+     *          If you want to create a SettingKey with a
+     *          default value, use the {@link #of(String, Object, SettingConverter)}
+     *          method instead.
+     */
+    public static <T> SettingKey<T> of(String key, SettingConverter<T> converter) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        return new SettingKey<>(key, null, converter, false);
+    }
+
+    /**
+     * Creates a new SettingKey with the specified default value.
+     * 
+     * @param key          the key for the setting
+     * @param converter    the converter for the setting
+     * @param defaultValue the default value for the setting
+     * @param <T>          the type of the setting value
+     * @return a new SettingKey with the specified default value
+     * @exception NullPointerException if {@code key} or {@code converter} is null
+     * @apiNote This method is a convenience method for creating a
+     *          {@link SettingKey}
+     *          with a default value.<br>
+     *          If you want to create a SettingKey without a default value, use the
+     *          {@link #of(String, SettingConverter)} method instead.
+     */
+    public static <T> SettingKey<T> of(String key, T defaultValue, SettingConverter<T> converter) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(converter, "converter must not be null");
+        return new SettingKey<>(key, defaultValue, converter, true);
+    }
+
+    /**
+     * Returns the key for this SettingKey.
+     *
+     * @return the key for this SettingKey
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Returns the default value for this SettingKey.
+     *
+     * @return the default value for this SettingKey, or null if no default value is
+     *         set
+     */
+    public T getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Checks if this SettingKey has a default value.
+     *
+     * @return true if this SettingKey has a default value, false otherwise
+     */
+    public boolean hasDefaultValue() {
+        return hasDefaultValue;
+    }
+
+    /**
+     * Serializes the given value to a string using the converter.
+     *
+     * @param value the value to serialize
+     * @return the serialized string representation of the value
+     */
+    public String serialize(T value) {
+        return converter.serialize(value);
+    }
+
+    /**
+     * Deserializes the given string to a value using the converter.
+     *
+     * @param value the string to deserialize
+     * @return the deserialized value
+     */
+    public T deserialize(String value) {
+        return converter.deserialize(value);
+    }
+}

--- a/src/com/digero/common/settings/Settings.java
+++ b/src/com/digero/common/settings/Settings.java
@@ -1,0 +1,70 @@
+package com.digero.common.settings;
+
+import java.util.Objects;
+
+/**
+ * A class that provides access to application settings.
+ */
+public final class Settings {
+
+    private final SettingsStore store;
+
+    /**
+     * Creates a new Settings instance with the specified store.
+     *
+     * @param store the settings store
+     * @throws NullPointerException if {@code store} is null
+     */
+    public Settings(SettingsStore store) {
+        this.store = Objects.requireNonNull(store);
+    }
+
+    /**
+     * Returns the value associated with the specified key.
+     *
+     * @param key the setting key
+     * @param <T> the type of the setting value
+     * @return the value associated with the key
+     */
+    public <T> T get(SettingKey<T> key) {
+        return store.get(key);
+    }
+
+    /**
+     * Returns true if the store contains a value for the specified key.
+     *
+     * @param key the setting key
+     * @return true if the store contains a value for the key, false otherwise
+     */
+    public boolean contains(SettingKey<?> key) {
+        return store.contains(key);
+    }
+
+    /**
+     * Sets the value associated with the specified key.
+     *
+     * @param key   the setting key
+     * @param value the value to set
+     * @param <T>   the type of the setting value
+     */
+    public <T> void set(SettingKey<T> key, T value) {
+        store.set(key, value);
+    }
+
+    /**
+     * Removes the value associated with the specified key.
+     *
+     * @param key the setting key
+     */
+    public void remove(SettingKey<?> key) {
+        store.remove(key);
+    }
+
+    /**
+     * Clears all settings.
+     */
+    public void clear() {
+        store.clear();
+    }
+
+}

--- a/src/com/digero/common/settings/Settings.java
+++ b/src/com/digero/common/settings/Settings.java
@@ -67,4 +67,11 @@ public final class Settings {
         store.clear();
     }
 
+    /**
+     * Flushes any changes to the underlying storage.
+     */
+    public void flush() {
+        store.flush();
+    }
+
 }

--- a/src/com/digero/common/settings/SettingsException.java
+++ b/src/com/digero/common/settings/SettingsException.java
@@ -1,0 +1,29 @@
+package com.digero.common.settings;
+
+/**
+ * Exception thrown when an error occurs while accessing or modifying settings.
+ */
+public class SettingsException extends RuntimeException {
+
+    /**
+     * Constructs a new SettingsException with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public SettingsException(String message) {
+        super(message);
+
+    }
+
+    /**
+     * Constructs a new SettingsException with the specified detail message and
+     * cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause of the exception
+     */
+    public SettingsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/com/digero/common/settings/SettingsStore.java
+++ b/src/com/digero/common/settings/SettingsStore.java
@@ -14,6 +14,7 @@ public interface SettingsStore {
      * @param key the setting key
      * @param <T> the type of the setting value
      * @return the value of the setting, or null if no value is set
+     * @throws SettingsException if an error occurs while retrieving the setting
      */
     <T> T get(SettingKey<T> key);
 
@@ -31,6 +32,7 @@ public interface SettingsStore {
      * @param key   the setting key
      * @param value the value to set
      * @param <T>   the type of the setting value
+     * @throws SettingsException if an error occurs while setting the value
      */
     <T> void set(SettingKey<T> key, T value);
 
@@ -38,11 +40,21 @@ public interface SettingsStore {
      * Removes the setting for the given key.
      * 
      * @param key the setting key
+     * @throws SettingsException if an error occurs while removing the setting
      */
     void remove(SettingKey<?> key);
 
     /**
      * Removes all settings.
+     * 
+     * @throws SettingsException if an error occurs while clearing the settings
      */
     void clear();
+
+    /**
+     * Flushes any changes to the underlying storage.
+     *
+     * @throws SettingsException if an error occurs while flushing the settings
+     */
+    void flush();
 }

--- a/src/com/digero/common/settings/SettingsStore.java
+++ b/src/com/digero/common/settings/SettingsStore.java
@@ -1,0 +1,48 @@
+package com.digero.common.settings;
+
+/**
+ * A store for application settings. Implementations of this interface are
+ * responsible for persisting settings to a storage medium (e.g., file,
+ * database).
+ */
+public interface SettingsStore {
+
+    /**
+     * Returns the value of the setting for the given key, or null if no value is
+     * set.
+     * 
+     * @param key the setting key
+     * @param <T> the type of the setting value
+     * @return the value of the setting, or null if no value is set
+     */
+    <T> T get(SettingKey<T> key);
+
+    /**
+     * Returns true if the store contains a value for the given key.
+     * 
+     * @param key the setting key
+     * @return true if the store contains a value for the key, false otherwise
+     */
+    boolean contains(SettingKey<?> key);
+
+    /**
+     * Sets the value of the setting for the given key.
+     * 
+     * @param key   the setting key
+     * @param value the value to set
+     * @param <T>   the type of the setting value
+     */
+    <T> void set(SettingKey<T> key, T value);
+
+    /**
+     * Removes the setting for the given key.
+     * 
+     * @param key the setting key
+     */
+    void remove(SettingKey<?> key);
+
+    /**
+     * Removes all settings.
+     */
+    void clear();
+}

--- a/src/com/digero/common/settings/converter/DefaultConverters.java
+++ b/src/com/digero/common/settings/converter/DefaultConverters.java
@@ -1,0 +1,43 @@
+package com.digero.common.settings.converter;
+
+import com.digero.common.settings.SettingConverter;
+
+public final class DefaultConverters {
+
+    private DefaultConverters() {
+        // Prevent instantiation
+    }
+
+    public static final SettingConverter<String> STRING = new SettingConverter<>() {
+        public String deserialize(String value) {
+            return value;
+        }
+
+        public String serialize(String value) {
+            return value;
+        }
+    };
+
+    public static final SettingConverter<Integer> INTEGER = new SettingConverter<>() {
+        public Integer deserialize(String value) {
+            return Integer.valueOf(value);
+        }
+
+        public String serialize(Integer value) {
+            return String.valueOf(value);
+        }
+    };
+
+    public static final SettingConverter<Boolean> BOOLEAN = new SettingConverter<Boolean>() {
+        @Override
+        public String serialize(Boolean value) {
+            return Boolean.toString(value);
+        }
+
+        @Override
+        public Boolean deserialize(String value) {
+            return Boolean.parseBoolean(value);
+        }
+    };
+
+}

--- a/src/com/digero/common/settings/converter/DefaultConverters.java
+++ b/src/com/digero/common/settings/converter/DefaultConverters.java
@@ -1,5 +1,7 @@
 package com.digero.common.settings.converter;
 
+import java.util.Locale;
+
 import com.digero.common.settings.SettingConverter;
 
 public final class DefaultConverters {
@@ -37,6 +39,26 @@ public final class DefaultConverters {
         @Override
         public Boolean deserialize(String value) {
             return Boolean.parseBoolean(value);
+        }
+    };
+
+    public static final SettingConverter<Double> DOUBLE = new SettingConverter<>() {
+        public Double deserialize(String value) {
+            return Double.valueOf(value);
+        }
+
+        public String serialize(Double value) {
+            return String.valueOf(value);
+        }
+    };
+
+    public static final SettingConverter<Locale> LOCALE = new SettingConverter<>() {
+        public Locale deserialize(String value) {
+            return Locale.forLanguageTag(value);
+        }
+
+        public String serialize(Locale value) {
+            return value.toLanguageTag();
         }
     };
 

--- a/src/com/digero/common/settings/converter/DefaultConverters.java
+++ b/src/com/digero/common/settings/converter/DefaultConverters.java
@@ -11,20 +11,24 @@ public final class DefaultConverters {
     }
 
     public static final SettingConverter<String> STRING = new SettingConverter<>() {
+        @Override
         public String deserialize(String value) {
             return value;
         }
 
+        @Override
         public String serialize(String value) {
             return value;
         }
     };
 
     public static final SettingConverter<Integer> INTEGER = new SettingConverter<>() {
+        @Override
         public Integer deserialize(String value) {
             return Integer.valueOf(value);
         }
 
+        @Override
         public String serialize(Integer value) {
             return String.valueOf(value);
         }
@@ -43,23 +47,26 @@ public final class DefaultConverters {
     };
 
     public static final SettingConverter<Double> DOUBLE = new SettingConverter<>() {
+        @Override
         public Double deserialize(String value) {
             return Double.valueOf(value);
         }
 
+        @Override
         public String serialize(Double value) {
             return String.valueOf(value);
         }
     };
 
     public static final SettingConverter<Locale> LOCALE = new SettingConverter<>() {
+        @Override
         public Locale deserialize(String value) {
             return Locale.forLanguageTag(value);
         }
 
+        @Override
         public String serialize(Locale value) {
             return value.toLanguageTag();
         }
     };
-
 }

--- a/src/com/digero/common/settings/store/InMemorySettingsStore.java
+++ b/src/com/digero/common/settings/store/InMemorySettingsStore.java
@@ -1,0 +1,112 @@
+package com.digero.common.settings.store;
+
+import com.digero.common.settings.SettingKey;
+import com.digero.common.settings.SettingsException;
+import com.digero.common.settings.SettingsStore;
+import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An in-memory implementation of the SettingsStore interface. This store keeps
+ * settings in memory and does not persist them.
+ */
+public class InMemorySettingsStore implements SettingsStore {
+
+    private final Map<String, String> values = new HashMap<>();
+
+    public InMemorySettingsStore() {
+    }
+
+    /**
+     * Retrieves the value of the specified setting key from the store.
+     *
+     * @param key the setting key to retrieve
+     * @param <T> the type of the setting value
+     * @return the value of the setting, or the default value if not found
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while deserializing the
+     *                              setting
+     */
+    @Override
+    public <T> T get(SettingKey<T> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+
+        String value = values.get(key.getKey());
+        if (value == null) {
+            return key.getDefaultValue();
+        }
+        try {
+            return key.deserialize(value);
+        } catch (ClassCastException e) {
+            throw new SettingsException("Failed to deserialize setting for key: " + key.getKey(), e);
+        }
+    }
+
+    /**
+     * Checks if the specified setting key exists in the store.
+     *
+     * @param key the setting key to check
+     * @return true if the setting exists, false otherwise
+     * @throws NullPointerException if {@code key} is null
+     */
+    @Override
+    public boolean contains(SettingKey<?> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+        return values.containsKey(key.getKey());
+    }
+
+    /**
+     * Sets the value of the specified setting key in the store.
+     *
+     * @param key   the setting key to set
+     * @param value the value to set for the setting key
+     * @param <T>   the type of the setting value
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while serializing the value
+     */
+    @Override
+    public <T> void set(SettingKey<T> key, T value) {
+        Objects.requireNonNull(key, "key cannot be null");
+
+        if (value == null) {
+            remove(key);
+            return;
+        }
+        try {
+            values.put(key.getKey(), key.serialize(value));
+        } catch (UnsupportedOperationException | ClassCastException | IllegalArgumentException e) {
+            throw new SettingsException("Failed to serialize setting for key: " + key.getKey(), e);
+        }
+    }
+
+    /**
+     * Removes the specified setting key from the store.
+     *
+     * @param key the setting key to remove
+     * @throws NullPointerException if {@code key} is null
+     */
+    @Override
+    public void remove(SettingKey<?> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+        values.remove(key.getKey());
+    }
+
+    /**
+     * Clears all settings from the store.
+     */
+    @Override
+    public void clear() {
+        values.clear();
+    }
+
+    /**
+     * Flushes the settings to the underlying storage. This is a no-op for the
+     * InMemorySettingsStore since it does not support persistent storage.
+     */
+    @Override
+    public void flush() {
+        // No-op for in-memory store; nothing to flush
+    }
+
+}

--- a/src/com/digero/common/settings/store/InMemorySettingsStore.java
+++ b/src/com/digero/common/settings/store/InMemorySettingsStore.java
@@ -23,10 +23,10 @@ public class InMemorySettingsStore implements SettingsStore {
      *
      * @param key the setting key to retrieve
      * @param <T> the type of the setting value
-     * @return the value of the setting, or the default value if not found
+     * @return the value of the setting, the default value if no value is set,
+     *         otherwise null if no default value is defined
      * @throws NullPointerException if {@code key} is null
-     * @throws SettingsException    if an error occurs while deserializing the
-     *                              setting
+     * @throws SettingsException    if an error occurs while deserializing the value
      */
     @Override
     public <T> T get(SettingKey<T> key) {
@@ -34,11 +34,15 @@ public class InMemorySettingsStore implements SettingsStore {
 
         String value = values.get(key.getKey());
         if (value == null) {
-            return key.getDefaultValue();
+            // Return the default value if the key has a default value, otherwise return
+            // null
+            return key.hasDefaultValue()
+                    ? key.getDefaultValue()
+                    : null;
         }
         try {
             return key.deserialize(value);
-        } catch (ClassCastException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to deserialize setting for key: " + key.getKey(), e);
         }
     }
@@ -69,13 +73,14 @@ public class InMemorySettingsStore implements SettingsStore {
     public <T> void set(SettingKey<T> key, T value) {
         Objects.requireNonNull(key, "key cannot be null");
 
+        // If the value is null, remove the key from the store
         if (value == null) {
             remove(key);
             return;
         }
         try {
             values.put(key.getKey(), key.serialize(value));
-        } catch (UnsupportedOperationException | ClassCastException | IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to serialize setting for key: " + key.getKey(), e);
         }
     }

--- a/src/com/digero/common/settings/store/PreferencesSettingsStore.java
+++ b/src/com/digero/common/settings/store/PreferencesSettingsStore.java
@@ -27,9 +27,10 @@ public final class PreferencesSettingsStore implements SettingsStore {
      *
      * @param key the setting key to retrieve
      * @param <T> the type of the setting value
-     * @return the value of the setting, or the default value if not found
+     * @return the value of the setting, the default value if no value is set,
+     *         otherwise null if no default value is defined
      * @throws NullPointerException if {@code key} is null
-     * @throws SettingsException    if an error occurs while retrieving the setting
+     * @throws SettingsException    if an error occurs while deserializing the value
      */
     @Override
     public <T> T get(SettingKey<T> key) {
@@ -37,10 +38,12 @@ public final class PreferencesSettingsStore implements SettingsStore {
         try {
             String value = preferences.get(key.getKey(), null);
             if (value == null) {
-                return key.getDefaultValue();
+                return key.hasDefaultValue()
+                        ? key.getDefaultValue()
+                        : null;
             }
             return key.deserialize(value);
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to get setting for key: " + key.getKey(), e);
         }
     }
@@ -58,7 +61,7 @@ public final class PreferencesSettingsStore implements SettingsStore {
         Objects.requireNonNull(key, "key cannot be null");
         try {
             return preferences.get(key.getKey(), null) != null;
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to check if setting exists for key: " + key.getKey(), e);
         }
     }
@@ -80,7 +83,7 @@ public final class PreferencesSettingsStore implements SettingsStore {
                 return;
             }
             preferences.put(key.getKey(), key.serialize(value));
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to set setting for key: " + key.getKey(), e);
         }
     }
@@ -97,7 +100,7 @@ public final class PreferencesSettingsStore implements SettingsStore {
         Objects.requireNonNull(key, "key cannot be null");
         try {
             preferences.remove(key.getKey());
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             throw new SettingsException("Failed to remove setting for key: " + key.getKey(), e);
         }
     }
@@ -111,7 +114,7 @@ public final class PreferencesSettingsStore implements SettingsStore {
     public void clear() {
         try {
             preferences.clear();
-        } catch (BackingStoreException | IllegalStateException e) {
+        } catch (BackingStoreException | RuntimeException e) {
             throw new SettingsException("Failed to clear preferences", e);
         }
     }

--- a/src/com/digero/common/settings/store/PreferencesSettingsStore.java
+++ b/src/com/digero/common/settings/store/PreferencesSettingsStore.java
@@ -1,14 +1,15 @@
 package com.digero.common.settings.store;
 
-import java.util.logging.Logger;
+import com.digero.common.settings.SettingsException;
+
 import java.util.Objects;
 import com.digero.common.settings.SettingsStore;
 import com.digero.common.settings.SettingKey;
+
+import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 public final class PreferencesSettingsStore implements SettingsStore {
-
-    private static final Logger LOGGER = Logger.getLogger(PreferencesSettingsStore.class.getName());
     private final Preferences preferences;
 
     /**
@@ -21,33 +22,106 @@ public final class PreferencesSettingsStore implements SettingsStore {
         this.preferences = Objects.requireNonNull(preferences, "preferences cannot be null");
     }
 
+    /**
+     * Retrieves the value of the specified setting key from the store.
+     *
+     * @param key the setting key to retrieve
+     * @param <T> the type of the setting value
+     * @return the value of the setting, or the default value if not found
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while retrieving the setting
+     */
     @Override
     public <T> T get(SettingKey<T> key) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'get'");
+        Objects.requireNonNull(key, "key cannot be null");
+        try {
+            String value = preferences.get(key.getKey(), null);
+            if (value == null) {
+                return key.getDefaultValue();
+            }
+            return key.deserialize(value);
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new SettingsException("Failed to get setting for key: " + key.getKey(), e);
+        }
     }
 
+    /**
+     * Checks if the specified setting key exists in the store.
+     *
+     * @param key the setting key to check
+     * @return true if the setting exists, false otherwise
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while checking the setting
+     */
     @Override
     public boolean contains(SettingKey<?> key) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'contains'");
+        Objects.requireNonNull(key, "key cannot be null");
+        try {
+            return preferences.get(key.getKey(), null) != null;
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new SettingsException("Failed to check if setting exists for key: " + key.getKey(), e);
+        }
     }
 
+    /**
+     * Sets the value of the specified setting key.
+     *
+     * @param key   the setting key
+     * @param value the value to set, or null to remove the setting
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while setting the value
+     */
     @Override
     public <T> void set(SettingKey<T> key, T value) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'set'");
+        Objects.requireNonNull(key, "key cannot be null");
+        try {
+            if (value == null) {
+                remove(key);
+                return;
+            }
+            preferences.put(key.getKey(), key.serialize(value));
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new SettingsException("Failed to set setting for key: " + key.getKey(), e);
+        }
     }
 
+    /**
+     * Removes the specified setting key from the store.
+     *
+     * @param key the setting key to remove
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while removing the setting
+     */
     @Override
     public void remove(SettingKey<?> key) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'remove'");
+        Objects.requireNonNull(key, "key cannot be null");
+        try {
+            preferences.remove(key.getKey());
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new SettingsException("Failed to remove setting for key: " + key.getKey(), e);
+        }
+    }
+
+    /**
+     * Clears all settings from the store.
+     *
+     * @throws SettingsException if an error occurs while clearing the settings
+     */
+    @Override
+    public void clear() {
+        try {
+            preferences.clear();
+        } catch (BackingStoreException | IllegalStateException e) {
+            throw new SettingsException("Failed to clear preferences", e);
+        }
     }
 
     @Override
-    public void clear() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'clear'");
+    public void flush() {
+        try {
+            preferences.flush();
+        } catch (BackingStoreException e) {
+            throw new SettingsException("Failed to flush settings", e);
+        }
     }
 }

--- a/src/com/digero/common/settings/store/PreferencesSettingsStore.java
+++ b/src/com/digero/common/settings/store/PreferencesSettingsStore.java
@@ -1,0 +1,53 @@
+package com.digero.common.settings.store;
+
+import java.util.logging.Logger;
+import java.util.Objects;
+import com.digero.common.settings.SettingsStore;
+import com.digero.common.settings.SettingKey;
+import java.util.prefs.Preferences;
+
+public final class PreferencesSettingsStore implements SettingsStore {
+
+    private static final Logger LOGGER = Logger.getLogger(PreferencesSettingsStore.class.getName());
+    private final Preferences preferences;
+
+    /**
+     * Creates a new PreferencesSettingsStore with the specified Preferences node.
+     *
+     * @param preferences the Preferences node to use for storing settings
+     * @throws NullPointerException if {@code preferences} is null
+     */
+    public PreferencesSettingsStore(Preferences preferences) {
+        this.preferences = Objects.requireNonNull(preferences, "preferences cannot be null");
+    }
+
+    @Override
+    public <T> T get(SettingKey<T> key) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'get'");
+    }
+
+    @Override
+    public boolean contains(SettingKey<?> key) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'contains'");
+    }
+
+    @Override
+    public <T> void set(SettingKey<T> key, T value) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'set'");
+    }
+
+    @Override
+    public void remove(SettingKey<?> key) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'remove'");
+    }
+
+    @Override
+    public void clear() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'clear'");
+    }
+}

--- a/src/com/digero/common/settings/store/PropertiesSettingsStore.java
+++ b/src/com/digero/common/settings/store/PropertiesSettingsStore.java
@@ -37,7 +37,8 @@ public final class PropertiesSettingsStore implements SettingsStore {
      *
      * @param <T> the type of the setting value
      * @param key the setting key
-     * @return the value associated with the key, or the default value if not found
+     * @return the value associated with the key, the default value if not found,
+     *         otherwise null if no default value is defined
      * @throws NullPointerException if {@code key} is null
      * @throws SettingsException    if an error occurs while deserializing the value
      */
@@ -47,12 +48,14 @@ public final class PropertiesSettingsStore implements SettingsStore {
         String value = properties.getProperty(key.getKey());
 
         if (value == null) {
-            return key.getDefaultValue();
+            return key.hasDefaultValue()
+                    ? key.getDefaultValue()
+                    : null;
         }
 
         try {
             return key.deserialize(value);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new SettingsException(
                     "Failed to deserialize setting: " + key.getKey(), e);
         }
@@ -87,8 +90,12 @@ public final class PropertiesSettingsStore implements SettingsStore {
             remove(key);
             return;
         }
-
-        properties.setProperty(key.getKey(), key.serialize(value));
+        try {
+            properties.setProperty(key.getKey(), key.serialize(value));
+        } catch (RuntimeException e) {
+            throw new SettingsException(
+                    "Failed to serialize setting: " + key.getKey(), e);
+        }
     }
 
     /**

--- a/src/com/digero/common/settings/store/PropertiesSettingsStore.java
+++ b/src/com/digero/common/settings/store/PropertiesSettingsStore.java
@@ -1,0 +1,156 @@
+package com.digero.common.settings.store;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Properties;
+import com.digero.common.settings.SettingKey;
+import com.digero.common.settings.SettingsException;
+import com.digero.common.settings.SettingsStore;
+
+/**
+ * A settings store that uses a properties file to persist settings.
+ */
+public final class PropertiesSettingsStore implements SettingsStore {
+    private final Properties properties;
+    private final Path filePath;
+
+    /**
+     * Constructs a new PropertiesSettingsStore with the specified file path.
+     *
+     * @param filePath the path to the properties file
+     * @throws NullPointerException if {@code filePath} is null
+     * @throws SettingsException    if an error occurs while loading the properties
+     */
+    public PropertiesSettingsStore(Path filePath) {
+        this.properties = new Properties();
+        this.filePath = Objects.requireNonNull(filePath, "filePath cannot be null");
+        load();
+    }
+
+    /**
+     * Retrieves the value associated with the specified setting key.
+     *
+     * @param <T> the type of the setting value
+     * @param key the setting key
+     * @return the value associated with the key, or the default value if not found
+     * @throws NullPointerException if {@code key} is null
+     * @throws SettingsException    if an error occurs while deserializing the value
+     */
+    @Override
+    public <T> T get(SettingKey<T> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+        String value = properties.getProperty(key.getKey());
+
+        if (value == null) {
+            return key.getDefaultValue();
+        }
+
+        try {
+            return key.deserialize(value);
+        } catch (Exception e) {
+            throw new SettingsException(
+                    "Failed to deserialize setting: " + key.getKey(), e);
+        }
+    }
+
+    /**
+     * Checks if the specified setting key exists in the properties.
+     *
+     * @param key the setting key
+     * @return true if the key exists, false otherwise
+     * @throws NullPointerException if {@code key} is null
+     */
+    @Override
+    public boolean contains(SettingKey<?> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+        return properties.containsKey(key.getKey());
+    }
+
+    /**
+     * Sets the value associated with the specified setting key.
+     *
+     * @param <T>   the type of the setting value
+     * @param key   the setting key
+     * @param value the value to set; if null, the key will be removed
+     * @throws NullPointerException if {@code key} is null
+     */
+    @Override
+    public <T> void set(SettingKey<T> key, T value) {
+        Objects.requireNonNull(key, "key cannot be null");
+
+        if (value == null) {
+            remove(key);
+            return;
+        }
+
+        properties.setProperty(key.getKey(), key.serialize(value));
+    }
+
+    /**
+     * Removes the specified setting key from the properties.
+     *
+     * @param key the setting key to remove
+     * @throws NullPointerException if {@code key} is null
+     */
+    @Override
+    public void remove(SettingKey<?> key) {
+        Objects.requireNonNull(key, "key cannot be null");
+        properties.remove(key.getKey());
+    }
+
+    /**
+     * Clears all settings from the properties.
+     */
+    @Override
+    public void clear() {
+        properties.clear();
+    }
+
+    /**
+     * Saves the properties to the specified file path.
+     *
+     * @throws SettingsException if an error occurs while saving
+     */
+    @Override
+    public void flush() {
+        try {
+
+            // Ensure the parent directory exists before saving the properties file
+            Path parentDir = filePath.getParent();
+            if (parentDir != null) {
+                Files.createDirectories(parentDir);
+            }
+
+            try (Writer writer = Files.newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
+                properties.store(writer, "Application Settings");
+            }
+
+        } catch (IOException e) {
+            throw new SettingsException("Failed to save settings to " + filePath, e);
+        }
+    }
+
+    /**
+     * Loads the properties from the specified file path.
+     *
+     * @throws SettingsException if an error occurs while loading
+     */
+    private void load() {
+        if (!Files.exists(filePath)) {
+            return;
+        }
+
+        try (Reader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+
+        } catch (IOException e) {
+            throw new SettingsException("Failed to load settings from " + filePath, e);
+        }
+    }
+
+}


### PR DESCRIPTION
This draft introduces a new type-safe settings library that provides a consistent API for managing application settings independently of the underlying storage implementation.

The library supports serialization and deserialization of arbitrary setting types through converters and allows different storage backends to be used interchangeably. It provides a unified API for accessing, modifying, and persisting settings while improving maintainability, testability, and future extensibility.

### Settings Core Library

* Added the `SettingKey` class, which represents a strongly typed setting definition including its key, optional default value, and converter for serialization/deserialization.
* Introduced the `SettingConverter` interface for converting setting values between their typed representation and their stored string representation.
* Added the `Settings` class as a high-level API for accessing and modifying settings through a `SettingsStore`.
* Defined the `SettingsStore` interface to abstract the underlying persistence mechanism and provide common operations such as get/set/remove/clear/flush.
* Added the `SettingsException` class for consistent error handling during settings operations.

### Converter and Store Implementations

* Added `DefaultConverters`, providing built-in converters for common types:
  * `String`
  * `Integer`
  * `Boolean`
  * `Double`
  * `Locale`
* Added `InMemorySettingsStore`, an in-memory implementation for testing and non-persistent use cases.
* Added `PreferencesSettingsStore`, a persistent implementation backed by Java Preferences.
* Added `PropertiesSettingsStore`, a persistent implementation using standard Java `.properties` files.

### Design Goals

* Provide strongly typed settings access.
* Separate settings handling from the underlying storage implementation.
* Centralize serialization and deserialization logic.
* Improve unit testing through interchangeable storage backends.
* Provide a reusable settings implementation

### Example Implementation

* Added `MaestroSettingsExample` demonstrating how an application-specific settings wrapper can be built on top of the library.

> [!NOTE]
> This PR is currently a draft. The intention is to review the overall API design and architecture before migrating the existing Maestro & AbcPlayer settings implementation.